### PR TITLE
Biblographical Entry

### DIFF
--- a/example/mu/example.dtx
+++ b/example/mu/example.dtx
@@ -103,6 +103,12 @@
 %% 
 %% The following section sets up the metadata of the thesis.
 %<*econ>
+%    \end{macrocode}
+% \changes{v1.0.0}{2021/03/04}{Added elements that are used 
+%   by thesis@bibEntry and thesis@titlePage: field, fieldEn
+%   departmentEn. [TV]}
+%    \begin{macrocode}
+
 \thesissetup{
     date               = \the\year/\the\month/\the\day,
     autoLayout         = false,
@@ -140,6 +146,8 @@
     %% The following keys are only useful, when you're using a
     %% locale other than English. You can safely omit them in an
     %% English thesis.
+    fieldEn        = Applied Econometrics,
+    departmentEn       = Department of Finance,
     titleEn            = The Economic Value of LaTeX,
     TeXtitleEn         = The Economic Value of \LaTeX,
     keywordsEn         = {keyword1, keyword2, ...},
@@ -152,11 +160,17 @@
 }
 %</econ>
 %<*fi>
+%    \end{macrocode}
+% \changes{v1.0.0}{2021/03/04}{Added elements that are used
+%   by thesis@titlePage: field, department. [TV]}
+%    \begin{macrocode}
 \thesissetup{
     date        = \the\year/\the\month/\the\day,
     university  = mu,
     faculty     = fi,
     type        = bc,
+    field       = Applied Informatics,
+    department  = Department of Machine Learning and Data Processing,
     author      = Jane Doe,
     gender      = f,
     advisor     = {Prof. RNDr. John Smith, CSc.},
@@ -182,28 +196,53 @@
 }
 %</fi>
 %<*fsps>
+%    \end{macrocode}
+% \changes{v1.0.0}{2021/03/04}{Added elements that are used
+%   by thesis@bibEntry and thesis@titlePage: field, fieldEn,
+%   department, departmentEn, titleEn, TeXtitleEn, keywords, 
+%   keywordsEn, TeXkeywords, TeXkeywordsEn. [TV]}
+%    \begin{macrocode}
 \thesissetup{
-    date       = \the\year/\the\month/\the\day,
-    university = mu,
-    faculty    = fsps,
-    type       = bc,
-    field      = Sport Management,
-    author     = Jane Doe,
-    gender     = f,
-    advisor    = {Prof. RNDr. John Smith, CSc.},
-    title      = The use of LaTeX for the Typesetting
-                 of Sports Tables,
-    TeXtitle   = The use of \LaTeX\ for the Typesetting
-                 of Sports Tables,
-    bib        = example.bib,
+    date          = \the\year/\the\month/\the\day,
+    university    = mu,
+    faculty       = fsps,
+    type          = bc,
+    field         = Sport Management,
+    department    = Department of Social Sciences and Sport Management,
+    author        = Jane Doe,
+    gender        = f,
+    advisor       = {Prof. RNDr. John Smith, CSc.},
+    title         = The use of LaTeX for the Typesetting
+                    of Sports Tables,
+    TeXtitle      = The use of \LaTeX\ for the Typesetting
+                    of Sports Tables,
+    keywords      = {keyword1, keywords2, ...},
+    TeXkeywords   = {keyword1, keywords2, \ldots},
+    bib           = example.bib,
+    %% The following keys are only useful, when you're using a
+    %% locale other than English. You can safely omit them in an
+    %% English thesis.
+    fieldEn       = Applied Econometrics,
+    departmentEn  = Department of Finance,
+    titleEn       = The Economic Value of LaTeX,
+    TeXtitleEn    = The Economic Value of \LaTeX,
+    keywordsEn    = {keyword1, keyword2, ...},
+    TeXkeywordsEn = {keyword1, keyword2, \ldots},
 }
 %</fsps>
 %<*fss>
+%    \end{macrocode}
+% \changes{v1.0.0}{2021/03/04}{Added elements that are used
+%   by thesis@bibEntry and thesis@titlePage: field, fieldEn,
+%   department, departmentEn, titleEn, TeXtitleEn. [TV]}
+%    \begin{macrocode}
 \thesissetup{
     date          = \the\year/\the\month/\the\day,
     university    = mu,
     faculty       = fss,
     type          = bc,
+    field         = Psychology,
+    department    = Department of Health,
     author        = Jane Doe,
     gender        = f,
     title         = LaTeX and Its Impact on the
@@ -226,6 +265,12 @@
     %% The following keys are only useful, when you're using a
     %% locale other than English. You can safely omit them in an
     %% English thesis.
+    fieldEn       = Psychology,
+    departmentEn  = Department of Health,
+    titleEn       = LaTeX and Its Impact on the
+                    Information Society,
+    TeXtitleEn    = \LaTeX\ and Its Impact on the
+                    Information Society,
     keywordsEn    = {keyword1, keyword2, ...},
     TeXkeywordsEn = {keyword1, keyword2, \ldots},
     abstractEn    = {%
@@ -236,12 +281,17 @@
 }
 %</fss>
 %<*law>
+%    \end{macrocode}
+% \changes{v1.0.0}{2021/03/04}{Added elements that are used
+%   by thesis@titlePage: field [TV]}
+%    \begin{macrocode}
 \thesissetup{
     date          = \the\year/\the\month/\the\day,
     university    = mu,
     faculty       = law,
-    department    = The Department of Commercial Law,
     type          = bc,
+    field         = Law and Finance,
+    department    = The Department of Commercial Law,
     author        = Jane Doe,
     gender        = f,
     title         = The Legal Aspects of the LaTeX Project
@@ -278,10 +328,10 @@
     date          = \the\year/\the\month/\the\day,
     university    = mu,
     faculty       = med,
+    type          = bc,
     field         = Optometry,
     department    = The Department of Optometry and
                     Orthoptics,
-    type          = bc,
     author        = Jane Doe,
     gender        = f,
     advisor       = {Prof. RNDr. John Smith, CSc.},
@@ -315,11 +365,17 @@
 }
 %</med>
 %<*ped>
+%    \end{macrocode}
+% \changes{v1.0.0}{2021/03/04}{Added elements that are used
+%   by thesis@bibEntry and thesis@titlePage: field, fieldEn,
+%   departmentEn, titleEn, TeXtitleEn. [TV]}
+%    \begin{macrocode}
 \thesissetup{
     date          = \the\year/\the\month/\the\day,
     university    = mu,
     faculty       = ped,
     type          = bc,
+    field         = Speech Therapy,
     department    = Department of Primary Pedagogy,
     author        = Jane Doe,
     gender        = f,
@@ -344,6 +400,12 @@
     %% The following keys are only useful, when you're using a
     %% locale other than English. You can safely omit them in an
     %% English thesis.
+    fieldEn       = Speech Therapy,
+    departmentEn  = Department of Primary Pedagogy,
+    titleEn       = The Challenges of Teaching LaTeX
+                    to Preschool Children,
+    TeXtitleEn    = The Challenges of Teaching \LaTeX\ 
+	            to Preschool Children,
     keywordsEn    = {keyword1, keyword2, ...},
     TeXkeywordsEn = {keyword1, keyword2, \ldots},
     abstractEn    = {%
@@ -354,26 +416,49 @@
 }
 %</ped>
 %<*phil>
+%    \end{macrocode}
+% \changes{v1.0.0}{2021/03/04}{Added elements that are used
+%   by thesis@bibEntry and thesis@titlePage: fieldEn, departmentEn,
+%   titleEn, TeXtitleEn, keywordsEn, TeXkeywordsEn, abstractEn. [TV]}
+%    \begin{macrocode}
 \thesissetup{
-    date       = \the\year/\the\month/\the\day,
-    university = mu,
-    faculty    = phil,
-    department = Department of Psychology,
-    field      = Cognitive Sciences,
-    type       = bc,
-    author     = Jane Doe,
-    gender     = f,
-    advisor    = {Prof. RNDr. John Smith, CSc.},
-    title      = What Can Typography Tell Us
-                 About the Nature of Man,
-    TeXtitle   = What Can Typography Tell Us\\
-                 About the Nature of Man,
-    thanks     = {%
+    date        = \the\year/\the\month/\the\day,
+    university  = mu,
+    faculty     = phil,
+    type        = bc,
+    field       = Cognitive Sciences,
+    department  = Department of Psychology,
+    author      = Jane Doe,
+    gender      = f,
+    advisor     = {Prof. RNDr. John Smith, CSc.},
+    title       = What Can Typography Tell Us
+                  About the Nature of Man,
+    TeXtitle    = What Can Typography Tell Us\\
+                  About the Nature of Man,
+    keywords    = {keyword1, keyword2, ...},
+    TeXkeywords = {keyword1, keyword2, \ldots},
+    thanks      = {%
       These are the acknowledgements for my thesis, which can
 
       span multiple paragraphs.
     },
     bib        = example.bib,
+    %% The following keys are only useful, when you're using a
+    %% locale other than English. You can safely omit them in an
+    %% English thesis.
+    fieldEn            = Cognitive Sciences,
+    departmentEn       = Department of Psychology,
+    titleEn            = What Can Typography Tell Us
+	                 About the Nature of Man,
+    TeXtitleEn         = What Can Typography Tell Us
+	                 About the Nature of Man,
+    keywordsEn         = {keyword1, keyword2, ...},
+    TeXkeywordsEn      = {keyword1, keyword2, \ldots},
+    abstractEn         = {%
+    This is the English abstract of my thesis, which can
+
+      span multiple paragraphs.
+    },
 }
 %</phil>
 %<*sci>

--- a/locale/czech.dtx
+++ b/locale/czech.dtx
@@ -194,7 +194,7 @@
 \gdef\thesis@czech@bib@programme{Studijní program}
 \global\let\thesis@czech@bib@field\thesis@czech@fieldTitle
 \gdef\thesis@czech@bib@academicYear{Akademický rok}
-gdef\thesis@czech@bib@pages{Počet stran}
+\gdef\thesis@czech@bib@pages{Počet stran}
 \global\let\thesis@czech@bib@keywords\thesis@czech@keywordsTitle
 
 % Různé

--- a/locale/czech.dtx
+++ b/locale/czech.dtx
@@ -185,6 +185,17 @@
 \global\let\thesis@czech@bib@author\thesis@czech@authorTitle
 \gdef\thesis@czech@bib@thesisTitle{Název práce}
 \global\let\thesis@czech@bib@advisor\thesis@czech@advisorTitle
+%    \end{macrocode}
+% \changes{v1.0.0}{2021/03/04}{Lifted the \texttt{bib@programme},
+%   \texttt{bib@academicYear}, and \texttt{bib@pages} strings from
+%   \texttt{locale/mu/sci/*.def} to \texttt{locale/mu/*.def},
+%   so that they can be shared with other faculties. [TV]}
+%    \begin{macrocode}
+\gdef\thesis@czech@bib@programme{Studijní program}
+\global\let\thesis@czech@bib@field\thesis@czech@fieldTitle
+\gdef\thesis@czech@bib@academicYear{Akademický rok}
+gdef\thesis@czech@bib@pages{Počet stran}
+\global\let\thesis@czech@bib@keywords\thesis@czech@keywordsTitle
 
 % Různé
 \gdef\thesis@czech@idTitle{UČO}
@@ -277,17 +288,6 @@
 
 % Zástupné texty
 \gdef\thesis@czech@facultyName{Ekonomicko-správní fakulta}
-
-% Bibliografický záznam
-%    \end{macrocode}
-% \changes{v0.3.46}{2017/06/02}{Defined strings required by
-%   \cs{thesis@blocks@bibEntry} from
-%   \texttt{style/mu/fithesis-econ.sty} in
-%   \texttt{locale/mu/econ/*.def}. [VN]}
-%    \begin{macrocode}
-\gdef\thesis@czech@bib@thesisTitleEn{Název práce v angličtině}
-\gdef\thesis@czech@bib@department{Katedra}
-\gdef\thesis@czech@bib@year{Rok obhajoby}
 
 % Různé
 %    \end{macrocode}
@@ -500,12 +500,6 @@
   statně s~využitím informačních zdrojů, které jsou v~práci
   citovány.}
 
-% Bibliografický záznam
-\gdef\thesis@czech@bib@programme{Studijní program}
-\global\let\thesis@czech@bib@field\thesis@czech@fieldTitle
-\gdef\thesis@czech@bib@academicYear{Akademický rok}
-\gdef\thesis@czech@bib@pages{Počet stran}
-\global\let\thesis@czech@bib@keywords\thesis@czech@keywordsTitle
 %    \end{macrocode}\iffalse
 %</mu/sci>
 % \fi

--- a/locale/english.dtx
+++ b/locale/english.dtx
@@ -165,6 +165,17 @@
 \global\let\thesis@english@bib@author\thesis@english@authorTitle
 \gdef\thesis@english@bib@thesisTitle{Title of Thesis}
 \gdef\thesis@english@bib@advisor{Supervisor}
+%    \end{macrocode}
+% \changes{v1.0.0}{2021/03/04}{Lifted the \texttt{bib@programme},
+%   \texttt{bib@academicYear}, and \texttt{bib@pages} strings from
+%   \texttt{locale/mu/sci/*.def} to \texttt{locale/mu/*.def},
+%   so that they can be shared with other faculties. [TV]}
+%    \begin{macrocode}
+\gdef\thesis@english@bib@programme{Degree Programme}
+\global\let\thesis@english@bib@field\thesis@english@fieldTitle
+\gdef\thesis@english@bib@academicYear{Academic Year}
+\gdef\thesis@english@bib@pages{Number of Pages}
+\global\let\thesis@english@bib@keywords\thesis@english@keywordsTitle
 
 % Miscellaneous
 \gdef\thesis@english@idTitle{UČO}
@@ -243,16 +254,6 @@
 % Placeholders
 \gdef\thesis@english@facultyName{Faculty of Economics
   and Administration}
-
-% Bibliographic entry
-%    \end{macrocode}
-% \changes{v0.3.46}{2017/06/02}{Defined strings required by
-%   \cs{thesis@blocks@bibEntry} from
-%   \texttt{style/mu/fithesis-econ.sty} in
-%   \texttt{locale/mu/econ/*.def}. [VN]}
-%    \begin{macrocode}
-\gdef\thesis@english@bib@department{Department}
-\gdef\thesis@english@bib@year{Year of Defense}
 
 % Miscellaneous
 %    \end{macrocode}
@@ -382,12 +383,6 @@
 % Miscellaneous
 \global\let\thesis@english@advisorTitleEn=\thesis@english@bib@advisor
 
-% Bibliographic entry
-\gdef\thesis@english@bib@programme{Degree Programme}
-\global\let\thesis@english@bib@field\thesis@english@fieldTitle
-\gdef\thesis@english@bib@academicYear{Academic Year}
-\gdef\thesis@english@bib@pages{Number of Pages}
-\global\let\thesis@english@bib@keywords\thesis@english@keywordsTitle
 %    \end{macrocode}\iffalse
 %</mu/sci>
 % \fi

--- a/locale/slovak.dtx
+++ b/locale/slovak.dtx
@@ -190,6 +190,17 @@
 \global\let\thesis@slovak@bib@author\thesis@slovak@authorTitle
 \gdef\thesis@slovak@bib@thesisTitle{Názov práce}
 \global\let\thesis@slovak@bib@advisor\thesis@slovak@advisorTitle
+%    \end{macrocode}
+% \changes{v1.0.0}{2021/03/04}{Lifted the \texttt{bib@programme},
+%   \texttt{bib@academicYear}, and \texttt{bib@pages} strings from
+%   \texttt{locale/mu/sci/*.def} to \texttt{locale/mu/*.def},
+%   so that they can be shared with other faculties. [TV]}
+%    \begin{macrocode}
+\gdef\thesis@slovak@bib@programme{Študijný program}
+\global\let\thesis@slovak@bib@field\thesis@slovak@fieldTitle
+\gdef\thesis@slovak@bib@academicYear{Akademický rok}
+\gdef\thesis@slovak@bib@pages{Počet strán}
+\global\let\thesis@slovak@bib@keywords\thesis@slovak@keywordsTitle
 
 % Rôzne
 \gdef\thesis@slovak@idTitle{UČO}
@@ -283,17 +294,6 @@
 
 % Zástupné texty
 \gdef\thesis@slovak@facultyName{Ekonomicko-správna fakulta}
-
-% Bibliografický záznam
-%    \end{macrocode}
-% \changes{v0.3.46}{2017/06/02}{Defined strings required by
-%   \cs{thesis@blocks@bibEntry} from
-%   \texttt{style/mu/fithesis-econ.sty} in
-%   \texttt{locale/mu/econ/*.def}. [VN]}
-%    \begin{macrocode}
-\gdef\thesis@slovak@bib@thesisTitleEn{Názov práce v angličtine}
-\gdef\thesis@slovak@bib@department{Katedra}
-\gdef\thesis@slovak@bib@year{Rok obhajoby}
 
 % Rôzne
 %    \end{macrocode}
@@ -494,12 +494,6 @@
 % Zástupné texty
 \gdef\thesis@slovak@facultyName{Prírodovedecká fakulta}
 
-% Bibliografický záznam
-\gdef\thesis@slovak@bib@programme{Študijný program}
-\global\let\thesis@slovak@bib@field\thesis@slovak@fieldTitle
-\gdef\thesis@slovak@bib@academicYear{Akademický rok}
-\gdef\thesis@slovak@bib@pages{Počet strán}
-\global\let\thesis@slovak@bib@keywords\thesis@slovak@keywordsTitle
 %    \end{macrocode}\iffalse
 %</mu/sci>
 % \fi

--- a/style/mu/base.dtx
+++ b/style/mu/base.dtx
@@ -1111,15 +1111,109 @@
 %   \item\texttt{bib@pages} -- The abbreviation of pages used in
 %     the bibliographical entry
 % \end{itemize}
+% \changes{v1.0.0}{2021/03/04}{The \cs{thesis@blocks@bibEntry} command
+%   was expanded to more closely resemble Faculty of Science's bibEntry.
+%   The \cs{thesis@blocks@bibEntryEn} was added. [TV]}
 %    \begin{macrocode}
 \def\thesis@blocks@bibEntry{%
+  \thesis@blocks@clear
   \chapter*{\thesis@@{bib@title}}
-  \noindent\thesis@upper{author@tail}, \thesis@author@head.
-  \emph{\thesis@title}. \thesis@place: \thesis@@{universityName},
-  \thesis@@{facultyName}, \thesis@department@name, \thesis@year.
-  \thesis@pages\ \thesis@@{bib@pages}.
-  \thesis@@{advisorTitle}: \thesis@advisor
-  \thesis@blocks@clearRight}
+  {% Calculate the width of the columns
+  \let\@A\relax\newlength{\@A}\settowidth{\@A}{{%
+    \bf\thesis@@{bib@author}:}}
+  \let\@B\relax\newlength{\@B}\settowidth{\@B}{{%
+    \bf\thesis@@{bib@thesisTitle}:}}
+  \let\@C\relax\newlength{\@C}\settowidth{\@C}{{%
+    \bf\thesis@@{bib@programme}:}}
+  \let\@D\relax\newlength{\@D}\settowidth{\@D}{{%
+    \bf\thesis@@{bib@field}:}}
+  \let\@E\relax\newlength{\@E}
+      \settowidth{\@E}{{\bf\thesis@@{bib@advisor}:}}
+  \let\@F\relax\newlength{\@F}\settowidth{\@F}{{%
+    \bf\thesis@@{bib@academicYear}:}}
+  \let\@G\relax\newlength{\@G}\settowidth{\@G}{{%
+    \bf\thesis@@{bib@pages}:}}
+  \let\@H\relax\newlength{\@H}\settowidth{\@H}{{%
+    \bf\thesis@@{bib@keywords}:}}
+  \let\@skip\relax\newlength{\@skip}\setlength{\@skip}{16pt}
+  \let\@left\relax\newlength{\@left}\pgfmathsetlength{\@left}{%
+    max(\@A,\@B,\@C,\@D,\@E,\@F,\@G,\@H)}
+  \let\@right\relax\newlength{\@right}\setlength{\@right}{%
+    \textwidth-\@left-\@skip}
+  % Typeset the table
+  \noindent\begin{thesis@newtable@old}%
+    {@{}p{\@left}@{\hskip\@skip}p{\@right}@{}}
+    \textbf{\thesis@@{bib@author}\ifthesis@woman ka\fi:} &
+      \noindent\parbox[t]{\@right}{
+        \thesis@author\\
+        \thesis@@{facultyName} \\
+        \thesis@@{universityName}\\
+        \thesis@department@name
+      }\\
+    \textbf{\thesis@@{bib@thesisTitle}:}
+      & \thesis@title \\
+    \textbf{\thesis@@{bib@programme}:}
+      & \thesis@programme \\
+    \textbf{\thesis@@{bib@advisor}:}
+      & \thesis@advisor \\
+    \textbf{\thesis@@{bib@academicYear}:}
+      & \thesis@academicYear \\
+    \textbf{\thesis@@{bib@pages}:}
+      & \thesis@pages \\
+    \textbf{\thesis@@{bib@keywords}:}
+      & \thesis@TeXkeywords \\
+  \end{thesis@newtable@old}}}
+
+\def\thesis@blocks@bibEntryEn{%
+  \ifthesis@english\else
+  \thesis@blocks@clear
+  \chapter*{\thesis@english@bib@title}
+  {% Calculate the width of the columns
+  \let\@A\relax\newlength{\@A}\settowidth{\@A}{{%
+    \bf\thesis@english@bib@author:}}
+  \let\@B\relax\newlength{\@B}\settowidth{\@B}{{%
+    \bf\thesis@english@bib@thesisTitle:}}
+  \let\@C\relax\newlength{\@C}\settowidth{\@C}{{%
+    \bf\thesis@english@bib@programme:}}
+  \let\@D\relax\newlength{\@D}\settowidth{\@D}{{%
+    \bf\thesis@english@bib@field:}}
+  \let\@E\relax\newlength{\@E}
+      \settowidth{\@E}{{\bf\thesis@english@bib@advisor:}}
+  \let\@F\relax\newlength{\@F}\settowidth{\@F}{{%
+    \bf\thesis@english@bib@academicYear:}}
+  \let\@G\relax\newlength{\@G}\settowidth{\@G}{{%
+    \bf\thesis@english@bib@pages:}}
+  \let\@H\relax\newlength{\@H}\settowidth{\@H}{{%
+    \bf\thesis@english@bib@keywords:}}
+  \let\@skip\relax\newlength{\@skip}\setlength{\@skip}{16pt}
+  \let\@left\relax\newlength{\@left}\pgfmathsetlength{\@left}{%
+    max(\@A,\@B,\@C,\@D,\@E,\@F,\@G,\@H)}
+  \let\@right\relax\newlength{\@right}\setlength{\@right}{%
+    \textwidth-\@left-\@skip}
+  % Typeset the table
+  \noindent\begin{thesis@newtable@old}%
+    {@{}p{\@left}@{\hskip\@skip}p{\@right}@{}}
+    \textbf{\thesis@@{bib@author}:} &
+      \noindent\parbox[t]{\@right}{
+        \thesis@author\\
+        \thesis@english@facultyName \\
+        \thesis@english@universityName\\
+        \thesis@departmentEn@name
+        }\\
+    \textbf{\thesis@english@bib@thesisTitle:}
+      & \thesis@titleEn \\
+    \textbf{\thesis@english@bib@programme:}
+      & \thesis@programmeEn \\
+    \textbf{\thesis@english@bib@advisor:}
+      & \thesis@advisor \\
+    \textbf{\thesis@english@bib@academicYear:}
+      & \thesis@academicYear \\
+    \textbf{\thesis@english@bib@pages:}
+      & \thesis@pages \\
+    \textbf{\thesis@english@bib@keywords:}
+      & \thesis@TeXkeywordsEn \\
+  \end{thesis@newtable@old}}
+  \fi}
 %    \end{macrocode}
 % \end{macro}\begin{macro}{\thesis@blocks@bibliography}
 % When |\ifthesis@bibliography@loaded@| is true and

--- a/style/mu/base.dtx
+++ b/style/mu/base.dtx
@@ -1162,7 +1162,7 @@
       & \thesis@pages \\
     \textbf{\thesis@@{bib@keywords}:}
       & \thesis@TeXkeywords \\
-  \end{thesis@newtable@old}}}
+  \end{thesis@newtable@old}}\fi}
 
 \def\thesis@blocks@bibEntryEn{%
   \ifthesis@english\else

--- a/style/mu/base.dtx
+++ b/style/mu/base.dtx
@@ -209,6 +209,8 @@
 %   \item\textsf{booktabs} -- A package, which allows the creation
 %     of publication-quality tables in \LaTeX.
 % \end{itemize}
+% \changes{v1.0.0}{2021/03/04}{Added required package tikz
+%   for bibEntry. [TV]}
 %    \begin{macrocode}
 \thesis@require{xcolor}
 \RequirePackage[labelfont=bf]{caption}
@@ -220,6 +222,7 @@
 \thesis@require{tabularx}
 \thesis@require{tabu}
 \thesis@require{booktabs}
+\thesis@require{tikz}
 %    \end{macrocode}
 % If the |\thesis@microtype@| is set to true, then the
 % \textsf{microtype} package gets loaded.
@@ -1137,7 +1140,7 @@
     \bf\thesis@@{bib@keywords}:}}
   \let\@skip\relax\newlength{\@skip}\setlength{\@skip}{16pt}
   \let\@left\relax\newlength{\@left}\pgfmathsetlength{\@left}{%
-    max(\@A,\@B,\@C,\@D,\@E,\@F,\@G,\@H)}
+	  max(\@A,\@B,\@C,\@D,\@E,\@F,\@G,\@H)}
   \let\@right\relax\newlength{\@right}\setlength{\@right}{%
     \textwidth-\@left-\@skip}
   % Typeset the table
@@ -1162,7 +1165,7 @@
       & \thesis@pages \\
     \textbf{\thesis@@{bib@keywords}:}
       & \thesis@TeXkeywords \\
-  \end{thesis@newtable@old}}\fi}
+  \end{thesis@newtable@old}}}
 
 \def\thesis@blocks@bibEntryEn{%
   \ifthesis@english\else
@@ -1187,7 +1190,7 @@
     \bf\thesis@english@bib@keywords:}}
   \let\@skip\relax\newlength{\@skip}\setlength{\@skip}{16pt}
   \let\@left\relax\newlength{\@left}\pgfmathsetlength{\@left}{%
-    max(\@A,\@B,\@C,\@D,\@E,\@F,\@G,\@H)}
+	  max(\@A,\@B,\@C,\@D,\@E,\@F,\@G,\@H)}
   \let\@right\relax\newlength{\@right}\setlength{\@right}{%
     \textwidth-\@left-\@skip}
   % Typeset the table

--- a/style/mu/base.dtx
+++ b/style/mu/base.dtx
@@ -1153,7 +1153,7 @@
     \textbf{\thesis@@{bib@thesisTitle}:}
       & \thesis@title \\
     \textbf{\thesis@@{bib@programme}:}
-      & \thesis@programme \\
+      & \thesis@field \\
     \textbf{\thesis@@{bib@advisor}:}
       & \thesis@advisor \\
     \textbf{\thesis@@{bib@academicYear}:}
@@ -1203,7 +1203,7 @@
     \textbf{\thesis@english@bib@thesisTitle:}
       & \thesis@titleEn \\
     \textbf{\thesis@english@bib@programme:}
-      & \thesis@programmeEn \\
+      & \thesis@fieldEn \\
     \textbf{\thesis@english@bib@advisor:}
       & \thesis@advisor \\
     \textbf{\thesis@english@bib@academicYear:}

--- a/style/mu/econ.dtx
+++ b/style/mu/econ.dtx
@@ -276,64 +276,8 @@
     \end{alwayssingle}}%
   \fi}
 %    \end{macrocode}
-% \end{macro}\begin{macro}{\thesis@blocks@bibEntry}
-% The |\thesis@blocks@bibEntry| macro typesets a bibliographical
-% entry. Along with the macros required by the locale file
-% interface, the locale files need to define the following macros:
-% \begin{itemize}
-%   \item|\thesis@|\textit{locale}|@bib@author| -- The label of the
-%     author name entry
-%   \item|\thesis@|\textit{locale}|@bib@title| -- The label of the
-%     title name entry
-%   \item|\thesis@|\textit{locale}|@bib@titleEn| -- The label of the
-%     English title name entry (\cs{thesis@english@bib@titleEn}
-%     does not need to be defined)
-%   \item|\thesis@|\textit{locale}|@bib@department| -- The label of
-%     the department name entry
-%   \item|\thesis@|\textit{locale}|@bib@advisor| -- The label of
-%     the advisor name entry
-%   \item|\thesis@|\textit{locale}|@bib@year| -- The label of the
-%     year entry
-% \end{itemize}
-% \changes{v0.3.46}{2017/06/02}{Defined \cs{thesis@blocks@bibEntry}
-%   in \texttt{style/mu/fithesis-econ.sty} in accordance with the
-%   example documents. The patch was submitted by Jana Ratajská.
-%   [VN]}
-% \changes{v0.3.51}{2020/03/09}{The \cs{thesis@blocks@bibEntry}
-%   command now accomodates long titles and other information that
-%   may span multiple lines. [VN]}
-%    \begin{macrocode}
-\def\thesis@blocks@bibEntry{%
-  \thesis@blocks@clear
-  {\let\@A\relax\newlength{\@A}
-   \settowidth{\@A}{{\bf\thesis@@{bib@author}}}
-   \@B=\@A
-   \settowidth{\@A}{{\bf\thesis@@{bib@thesisTitle}}}
-   \ifdim\@A>\@B\@B=\@A\fi
-   \ifthesis@english\else
-     \settowidth{\@A}{{\bf\thesis@@{bib@thesisTitleEn}}}
-     \ifdim\@A>\@B\@B=\@A\fi
-   \fi
-   \settowidth{\@A}{{\bf\thesis@@{bib@department}}}
-   \ifdim\@A>\@B\@B=\@A\fi
-   \settowidth{\@A}{{\bf\thesis@@{bib@advisor}}}
-   \ifdim\@A>\@B\@B=\@A\fi
-   \settowidth{\@A}{{\bf\thesis@@{bib@year}}}
-   \ifdim\@A>\@B\@B=\@A\fi
-   \noindent\begin{thesis@newtable@old}{@{}>{\bfseries}%
-                                        p{\dimexpr(\@B + \tabcolsep)}%
-                                        p{\dimexpr(\textwidth - \@B - 2\tabcolsep)}@{}}
-     \thesis@@{bib@author}:        & \thesis@author     \\
-     \thesis@@{bib@thesisTitle}:   & \thesis@title      \\
-   \ifthesis@english\else
-     \thesis@@{bib@thesisTitleEn}: & \thesis@titleEn    \\
-   \fi
-     \thesis@@{bib@department}:    & \thesis@department \\
-     \thesis@@{bib@advisor}:       & \thesis@advisor    \\
-     \thesis@@{bib@year}:          & \thesis@year       \\
-   \end{thesis@newtable@old}}}
-%    \end{macrocode}
 % \end{macro}
+
 % Note that there is no direct support for the seminar paper and
 % thesis proposal types.  If you would like to change the contents
 % of the preamble and the postamble, you should modify the


### PR DESCRIPTION
### Description
I changed the base `bibEntry`, `bibEntryEn` for all faculties by redefining them in `base.dtx` file according to my [Overleaf document](https://www.overleaf.com/project/60254b1bb116731e479c5e17) and adding relevant names for rows in the entry.

I have also updated the example documents with options in `\thesisSetup` which are also used in `\thesis@titlePage`. I left the bibEntry redefined for the Faculty of Science, as they require one extra field in their entry.

### Future Work

- [ ]  Few of the example documents were missing `abstract` in the `\thesisSetup`. That can be remedied perhaps while working on adding the `summary`.

Merging this pull request closes #1.