### PR TITLE
Summary

### DIFF
--- a/example/mu/example.dtx
+++ b/example/mu/example.dtx
@@ -149,6 +149,8 @@
 
       span multiple paragraphs.
     },
+    %% The following key is only useful when you are writing a
+    %% doctoral thesis. You can safely omit it in other theses.
     extra              = {
       summary          = {%
         This is the summary of my thesis, which should
@@ -381,6 +383,8 @@
       span multiple paragraphs.
     },
     bib        = example.bib,
+    %% The following key is only useful when you are writing a
+    %% doctoral thesis. You can safely omit it in other theses.
     extra      = {
       summary  = {%
         This is the summary of my thesis, which should

--- a/example/mu/example.dtx
+++ b/example/mu/example.dtx
@@ -149,6 +149,13 @@
 
       span multiple paragraphs.
     },
+    extra              = {
+      summary          = {%
+        This is the summary of my thesis, which should
+
+	not be very long.
+      },
+    },
 }
 %</econ>
 %<*fi>
@@ -374,6 +381,13 @@
       span multiple paragraphs.
     },
     bib        = example.bib,
+    extra      = {
+      summary  = {%
+        This is the summary of my thesis, which should
+
+	not be very long.
+      },
+    },
 }
 %</phil>
 %<*sci>

--- a/locale/czech.dtx
+++ b/locale/czech.dtx
@@ -74,6 +74,9 @@
   \fi\fi\fi\fi\fi\fi
   \thesis@year}}
 
+%    \end{macrocode}
+% \changes{v1.0.0}{2021/03/11}{Added title for summary. [TV]}
+%    \begin{macrocode}
 % Různé
 \gdef\thesis@czech@authorSignature{%
   Podpis autor\ifthesis@woman ky\else a\fi}
@@ -84,6 +87,7 @@
 \gdef\thesis@czech@keywordsTitle{Klíčová slova}
 \gdef\thesis@czech@thanksTitle{Poděkování}
 \gdef\thesis@czech@declarationTitle{Prohlášení}
+\gdef\thesis@czech@summaryTitle{Resumé}
 \gdef\thesis@czech@idTitle{ID}
 \gdef\thesis@czech@typeName@sempaper{Seminární práce}
 \gdef\thesis@czech@typeName@bachelors{Bakalářská práce}

--- a/locale/english.dtx
+++ b/locale/english.dtx
@@ -63,6 +63,9 @@
   \fi\fi\fi\fi\fi\fi
   \thesis@year}}
 
+%    \end{macrocode}
+% \changes{v1.0.0}{2021/03/11}{Added title for summary. [TV]}
+%    \begin{macrocode}
 % Miscellaneous
 \gdef\thesis@english@authorSignature{Author's signature}
 \gdef\thesis@english@fieldTitle{Field of study}
@@ -76,6 +79,7 @@
 %    \begin{macrocode}
 \gdef\thesis@english@thanksTitle{Acknowledgements}
 \gdef\thesis@english@declarationTitle{Declaration}
+\gdef\thesis@english@summaryTitle{Summary}
 \gdef\thesis@english@idTitle{ID}
 \gdef\thesis@english@typeName@sempaper{Seminar Paper}
 \gdef\thesis@english@typeName@bachelors{Bachelor's Thesis}

--- a/locale/slovak.dtx
+++ b/locale/slovak.dtx
@@ -74,6 +74,9 @@
   \fi\fi\fi\fi\fi\fi
   \thesis@year}}
 
+%    \end{macrocode}
+% \changes{v1.0.0}{2021/03/11}{Added title for summary. [TV]}
+%    \begin{macrocode}
 % Rôzne
 \gdef\thesis@slovak@authorSignature{%
   Podpis autor\ifthesis@woman ky\else a\fi}
@@ -84,6 +87,7 @@
 \gdef\thesis@slovak@keywordsTitle{Kľúčové slová}
 \gdef\thesis@slovak@thanksTitle{Poďakovanie}
 \gdef\thesis@slovak@declarationTitle{Vyhlásenie}
+\gdef\thesis@slovak@summaryTitle{Resumé}
 \gdef\thesis@slovak@idTitle{ID}
 \gdef\thesis@slovak@typeName@sempaper{Seminárna práca}
 \gdef\thesis@slovak@typeName@bachelors{Bakalárska práca}

--- a/style/mu/base.dtx
+++ b/style/mu/base.dtx
@@ -932,11 +932,13 @@
 % \end{macro}\begin{macro}{\thesis@blocks@abstract}
 % The |\thesis@blocks@abstract| macro typesets the
 % abstract.
+% \changes{v1.0.0}{2021/03/05}{Changed \texttt{clearpage}
+% to \texttt{vskip} so it is by default on the same page
+% when the template contains bibEntry. [TV]}
 % \begin{macrocode}
 \def\thesis@blocks@abstract{%
   \begin{alwayssingle}%
-    % Start the new chapter without clearing the left page.
-    \clearpage
+    \vskip 40 \p@
     {\let\thesis@blocks@clear\relax
     \chapter*{\thesis@@{abstractTitle}}}%
     \noindent\thesis@abstract
@@ -950,13 +952,15 @@
 % \changes{v0.3.46}{2017/06/02}{Simplified the definition of
 %   \cs{thesis@blocks@abstractEn} in
 %   \texttt{style/mu/fithesis-base.sty}. [VN]}
+% \changes{v1.0.0}{2021/03/05}{Changed \texttt{clearpage}
+% to \texttt{vskip} so it is by default on the same page
+% when the template contains bibEntry. [TV]}
 % \begin{macrocode}
 \def\thesis@blocks@abstractEn{%
   \ifthesis@english\else
     {\thesis@selectLocale{english}%
     \begin{alwayssingle}%
-      % Start the new chapter without clearing the left page.
-      \clearpage
+      \vskip 40 \p@
       {\let\thesis@blocks@clear\relax
       \chapter*{\thesis@english@abstractTitle}}%
       \noindent\thesis@abstractEn

--- a/style/mu/base.dtx
+++ b/style/mu/base.dtx
@@ -1115,15 +1115,109 @@
 %   \item\texttt{bib@pages} -- The abbreviation of pages used in
 %     the bibliographical entry
 % \end{itemize}
+% \changes{v1.0.0}{2021/03/04}{The \cs{thesis@blocks@bibEntry} command
+%   was expanded to more closely resemble Faculty of Science's bibEntry.
+%   The \cs{thesis@blocks@bibEntryEn} was added. [TV]}
 %    \begin{macrocode}
 \def\thesis@blocks@bibEntry{%
+  \thesis@blocks@clear
   \chapter*{\thesis@@{bib@title}}
-  \noindent\thesis@upper{author@tail}, \thesis@author@head.
-  \emph{\thesis@title}. \thesis@place: \thesis@@{universityName},
-  \thesis@@{facultyName}, \thesis@department@name, \thesis@year.
-  \thesis@pages\ \thesis@@{bib@pages}.
-  \thesis@@{advisorTitle}: \thesis@advisor
-  \thesis@blocks@clearRight}
+  {% Calculate the width of the columns
+  \let\@A\relax\newlength{\@A}\settowidth{\@A}{{%
+    \bf\thesis@@{bib@author}:}}
+  \let\@B\relax\newlength{\@B}\settowidth{\@B}{{%
+    \bf\thesis@@{bib@thesisTitle}:}}
+  \let\@C\relax\newlength{\@C}\settowidth{\@C}{{%
+    \bf\thesis@@{bib@programme}:}}
+  \let\@D\relax\newlength{\@D}\settowidth{\@D}{{%
+    \bf\thesis@@{bib@field}:}}
+  \let\@E\relax\newlength{\@E}
+      \settowidth{\@E}{{\bf\thesis@@{bib@advisor}:}}
+  \let\@F\relax\newlength{\@F}\settowidth{\@F}{{%
+    \bf\thesis@@{bib@academicYear}:}}
+  \let\@G\relax\newlength{\@G}\settowidth{\@G}{{%
+    \bf\thesis@@{bib@pages}:}}
+  \let\@H\relax\newlength{\@H}\settowidth{\@H}{{%
+    \bf\thesis@@{bib@keywords}:}}
+  \let\@skip\relax\newlength{\@skip}\setlength{\@skip}{16pt}
+  \let\@left\relax\newlength{\@left}\pgfmathsetlength{\@left}{%
+	  max(\@A,\@B,\@C,\@D,\@E,\@F,\@G,\@H)}
+  \let\@right\relax\newlength{\@right}\setlength{\@right}{%
+    \textwidth-\@left-\@skip}
+  % Typeset the table
+  \noindent\begin{thesis@newtable@old}%
+    {@{}p{\@left}@{\hskip\@skip}p{\@right}@{}}
+    \textbf{\thesis@@{bib@author}\ifthesis@woman ka\fi:} &
+      \noindent\parbox[t]{\@right}{
+        \thesis@author\\
+        \thesis@@{facultyName} \\
+        \thesis@@{universityName}\\
+        \thesis@department@name
+      }\\
+    \textbf{\thesis@@{bib@thesisTitle}:}
+      & \thesis@title \\
+    \textbf{\thesis@@{bib@programme}:}
+      & \thesis@field \\
+    \textbf{\thesis@@{bib@advisor}:}
+      & \thesis@advisor \\
+    \textbf{\thesis@@{bib@academicYear}:}
+      & \thesis@academicYear \\
+    \textbf{\thesis@@{bib@pages}:}
+      & \thesis@pages \\
+    \textbf{\thesis@@{bib@keywords}:}
+      & \thesis@TeXkeywords \\
+  \end{thesis@newtable@old}}}
+
+\def\thesis@blocks@bibEntryEn{%
+  \ifthesis@english\else
+  \thesis@blocks@clear
+  \chapter*{\thesis@english@bib@title}
+  {% Calculate the width of the columns
+  \let\@A\relax\newlength{\@A}\settowidth{\@A}{{%
+    \bf\thesis@english@bib@author:}}
+  \let\@B\relax\newlength{\@B}\settowidth{\@B}{{%
+    \bf\thesis@english@bib@thesisTitle:}}
+  \let\@C\relax\newlength{\@C}\settowidth{\@C}{{%
+    \bf\thesis@english@bib@programme:}}
+  \let\@D\relax\newlength{\@D}\settowidth{\@D}{{%
+    \bf\thesis@english@bib@field:}}
+  \let\@E\relax\newlength{\@E}
+      \settowidth{\@E}{{\bf\thesis@english@bib@advisor:}}
+  \let\@F\relax\newlength{\@F}\settowidth{\@F}{{%
+    \bf\thesis@english@bib@academicYear:}}
+  \let\@G\relax\newlength{\@G}\settowidth{\@G}{{%
+    \bf\thesis@english@bib@pages:}}
+  \let\@H\relax\newlength{\@H}\settowidth{\@H}{{%
+    \bf\thesis@english@bib@keywords:}}
+  \let\@skip\relax\newlength{\@skip}\setlength{\@skip}{16pt}
+  \let\@left\relax\newlength{\@left}\pgfmathsetlength{\@left}{%
+	  max(\@A,\@B,\@C,\@D,\@E,\@F,\@G,\@H)}
+  \let\@right\relax\newlength{\@right}\setlength{\@right}{%
+    \textwidth-\@left-\@skip}
+  % Typeset the table
+  \noindent\begin{thesis@newtable@old}%
+    {@{}p{\@left}@{\hskip\@skip}p{\@right}@{}}
+    \textbf{\thesis@@{bib@author}:} &
+      \noindent\parbox[t]{\@right}{
+        \thesis@author\\
+        \thesis@english@facultyName \\
+        \thesis@english@universityName\\
+        \thesis@departmentEn@name
+        }\\
+    \textbf{\thesis@english@bib@thesisTitle:}
+      & \thesis@titleEn \\
+    \textbf{\thesis@english@bib@programme:}
+      & \thesis@fieldEn \\
+    \textbf{\thesis@english@bib@advisor:}
+      & \thesis@advisor \\
+    \textbf{\thesis@english@bib@academicYear:}
+      & \thesis@academicYear \\
+    \textbf{\thesis@english@bib@pages:}
+      & \thesis@pages \\
+    \textbf{\thesis@english@bib@keywords:}
+      & \thesis@TeXkeywordsEn \\
+  \end{thesis@newtable@old}}
+  \fi}
 %    \end{macrocode}
 % \end{macro}\begin{macro}{\thesis@blocks@bibliography}
 % When |\ifthesis@bibliography@loaded@| is true and

--- a/style/mu/econ.dtx
+++ b/style/mu/econ.dtx
@@ -251,63 +251,6 @@
     \end{alwayssingle}}%
   \fi}
 %    \end{macrocode}
-% \end{macro}\begin{macro}{\thesis@blocks@bibEntry}
-% The |\thesis@blocks@bibEntry| macro typesets a bibliographical
-% entry. Along with the macros required by the locale file
-% interface, the locale files need to define the following macros:
-% \begin{itemize}
-%   \item|\thesis@|\textit{locale}|@bib@author| -- The label of the
-%     author name entry
-%   \item|\thesis@|\textit{locale}|@bib@title| -- The label of the
-%     title name entry
-%   \item|\thesis@|\textit{locale}|@bib@titleEn| -- The label of the
-%     English title name entry (\cs{thesis@english@bib@titleEn}
-%     does not need to be defined)
-%   \item|\thesis@|\textit{locale}|@bib@department| -- The label of
-%     the department name entry
-%   \item|\thesis@|\textit{locale}|@bib@advisor| -- The label of
-%     the advisor name entry
-%   \item|\thesis@|\textit{locale}|@bib@year| -- The label of the
-%     year entry
-% \end{itemize}
-% \changes{v0.3.46}{2017/06/02}{Defined \cs{thesis@blocks@bibEntry}
-%   in \texttt{style/mu/fithesis-econ.sty} in accordance with the
-%   example documents. The patch was submitted by Jana Ratajská.
-%   [VN]}
-% \changes{v0.3.51}{2020/03/09}{The \cs{thesis@blocks@bibEntry}
-%   command now accomodates long titles and other information that
-%   may span multiple lines. [VN]}
-%    \begin{macrocode}
-\def\thesis@blocks@bibEntry{%
-  \thesis@blocks@clear
-  {\let\@A\relax\newlength{\@A}
-   \settowidth{\@A}{{\bf\thesis@@{bib@author}}}
-   \@B=\@A
-   \settowidth{\@A}{{\bf\thesis@@{bib@thesisTitle}}}
-   \ifdim\@A>\@B\@B=\@A\fi
-   \ifthesis@english\else
-     \settowidth{\@A}{{\bf\thesis@@{bib@thesisTitleEn}}}
-     \ifdim\@A>\@B\@B=\@A\fi
-   \fi
-   \settowidth{\@A}{{\bf\thesis@@{bib@department}}}
-   \ifdim\@A>\@B\@B=\@A\fi
-   \settowidth{\@A}{{\bf\thesis@@{bib@advisor}}}
-   \ifdim\@A>\@B\@B=\@A\fi
-   \settowidth{\@A}{{\bf\thesis@@{bib@year}}}
-   \ifdim\@A>\@B\@B=\@A\fi
-   \noindent\begin{thesis@newtable@old}{@{}>{\bfseries}%
-                                        p{\dimexpr(\@B + \tabcolsep)}%
-                                        p{\dimexpr(\textwidth - \@B - 2\tabcolsep)}@{}}
-     \thesis@@{bib@author}:        & \thesis@author     \\
-     \thesis@@{bib@thesisTitle}:   & \thesis@title      \\
-   \ifthesis@english\else
-     \thesis@@{bib@thesisTitleEn}: & \thesis@titleEn    \\
-   \fi
-     \thesis@@{bib@department}:    & \thesis@department \\
-     \thesis@@{bib@advisor}:       & \thesis@advisor    \\
-     \thesis@@{bib@year}:          & \thesis@year       \\
-   \end{thesis@newtable@old}}}
-%    \end{macrocode}
 % \end{macro}\begin{macro}{\thesis@blocks@summary}
 % \changes{v1.0.0}{2021/03/11}{Macro for the summary was added. [TV]}
 % The |\thesis@blocks@summary| macro typesets the summary

--- a/style/mu/econ.dtx
+++ b/style/mu/econ.dtx
@@ -326,6 +326,7 @@
     \noindent\thesis@extra@summary
   \end{alwayssingle}}
 %    \end{macrocode}
+% \end{macro}
 
 % Note that there is no direct support for the seminar paper and
 % thesis proposal types.  If you would like to change the contents

--- a/style/mu/econ.dtx
+++ b/style/mu/econ.dtx
@@ -214,41 +214,16 @@
     \end{minipage}}
   \end{alwayssingle}}
 %    \end{macrocode}
-% \end{macro}\begin{macro}{\thesis@blocks@abstract}
+% \end{macro}
 % \changes{v0.3.46}{2017/06/02}{Redefined
 %   \cs{thesis@blocks@abstract}, \cs{thesis@blocks@abstractEn},
 %   \cs{thesis@blocks@keywords}, and \cs{thesis@blocks@keywordsEn}
 %   in \texttt{style/mu/fithesis-econ.sty} in accordance with the
 %   example documents. The patch was submitted by Jana Ratajská.
 %   [VN]}
-% The |\thesis@blocks@abstract| macro typesets the
-% abstract. This definition typesets the abstract on the same page.
-% \begin{macrocode}
-\def\thesis@blocks@abstract{%
-  \begin{alwayssingle}%
-    \vskip 40\p@
-    {\let\thesis@blocks@clear\relax
-    \chapter*{\thesis@@{abstractTitle}}}%
-    \noindent\thesis@abstract
-  \end{alwayssingle}}
-%    \end{macrocode}
-% \end{macro}\begin{macro}{\thesis@blocks@abstractEn}
-% The |\thesis@blocks@abstractEn| macro typesets the abstract in
-% English. If the current locale is English, the macro produces no
-% output. This macro typesets the abstract on the same page.
-% \begin{macrocode}
-\def\thesis@blocks@abstractEn{%
-  \ifthesis@english\else
-    {\thesis@selectLocale{english}%
-    \begin{alwayssingle}%
-      \vskip 20\p@
-      {\let\thesis@blocks@clear\relax
-      \chapter*{\thesis@english@abstractTitle}}%
-      \noindent\thesis@abstractEn
-    \end{alwayssingle}}%
-  \fi}
-%    \end{macrocode}
-% \end{macro}\begin{macro}{\thesis@blocks@keywords}
+% \changes{v1.0.0}{2021/03/11}{Macros for abstract and abstractEn
+%   were moved to \texttt{base.dtx}. [TV]}
+% \begin{macro}{\thesis@blocks@keywords}
 % The |\thesis@blocks@keywords| macro typesets the keywords. This
 % definition typesets the keywords on the same page.
 % \begin{macrocode}

--- a/style/mu/econ.dtx
+++ b/style/mu/econ.dtx
@@ -279,7 +279,6 @@
      \thesis@@{bib@year}:          & \thesis@year       \\
    \end{thesis@newtable@old}}}
 %    \end{macrocode}
->>>>>>> 09f8f938e0207fa38e327887f73a6b4532f1f4b0
 % \end{macro}\begin{macro}{\thesis@blocks@summary}
 % \changes{v1.0.0}{2021/03/11}{Macro for the summary was added. [TV]}
 % The |\thesis@blocks@summary| macro typesets the summary

--- a/style/mu/econ.dtx
+++ b/style/mu/econ.dtx
@@ -308,7 +308,25 @@
      \thesis@@{bib@year}:          & \thesis@year       \\
    \end{thesis@newtable@old}}}
 %    \end{macrocode}
-% \end{macro}
+% \end{macro}\begin{macro}{\thesis@blocks@summary}
+% \changes{v1.0.0}{2021/03/11}{Macro for the summary was added. [TV]}
+% The |\thesis@blocks@summary| macro typesets the summary
+% for doctoral theses. If the thesis type is not doctoral, the
+% macro produces no output.
+%    \begin{macrocode}
+\thesis@def@extra[{
+  \thesis@placeholder@extra@summary
+}]{summary}
+
+\def\thesis@blocks@summary{%
+  \begin{alwayssingle}%
+    \thesis@blocks@clear
+    {\let\thesis@blocks@clear\relax
+    \chapter*{\thesis@@{summaryTitle}}}%
+    \noindent\thesis@extra@summary
+  \end{alwayssingle}}
+%    \end{macrocode}
+
 % Note that there is no direct support for the seminar paper and
 % thesis proposal types.  If you would like to change the contents
 % of the preamble and the postamble, you should modify the
@@ -336,8 +354,11 @@
 % All blocks within the autolayout postamble that are not defined
 % within this file are defined in the \texttt{style/mu/base.sty}
 % file.
+% \changes{v1.0.0}{2021/03/11}{Added conditional to include summary
+% in doctoral theses. [TV]}
 %    \begin{macrocode}
 \def\thesis@blocks@postamble{%
+  \ifx\thesis@doctoral\thesis@type\thesis@blocks@summary\else\fi
   \thesis@blocks@bibliography
   \thesis@blocks@tables}
 %    \end{macrocode}

--- a/style/mu/phil.dtx
+++ b/style/mu/phil.dtx
@@ -70,7 +70,26 @@
   {\thesis@titlePage@large\\[0.3in]
     {\bf\thesis@@{advisorTitle}:} \thesis@advisor}}
 %    \end{macrocode}
+% \end{macro}\begin{macro}{\thesis@blocks@summary}
+% \changes{v1.0.0}{2021/03/11}{Macro for the summary was added. [TV]}
+% The |\thesis@blocks@summary| macro typesets the summary
+% for doctoral theses. If the thesis type is not doctoral, the
+% macro produces no output.
+%    \begin{macrocode}
+\thesis@def@extra[{
+  \thesis@placeholder@extra@summary
+}]{summary}
+
+\def\thesis@blocks@summary{%
+  \begin{alwayssingle}%
+    \thesis@blocks@clear
+    {\let\thesis@blocks@clear\relax
+    \chapter*{\thesis@@{summaryTitle}}}%
+    \noindent\thesis@extra@summary
+    \end{alwayssingle}}
+%    \end{macrocode}
 % \end{macro}
+
 % Note that there is no direct support for the seminar paper and
 % thesis proposal types.  If you would like to change the contents
 % of the preamble and the postamble, you should modify the
@@ -88,6 +107,8 @@
 %    \end{macrocode}
 % In KISK theses, the bibliographical entry, the abstract, and the
 % keywords will be included after the cover matter.
+% \changes{v1.0.0}{2021/03/11}{Added conditional to add summary for
+% doctoral theses. [TV]}
 %    \begin{macrocode}
     \ifx\thesis@department\thesis@departments@kisk
       \thesis@blocks@bibEntry
@@ -97,6 +118,7 @@
       \thesis@blocks@keywordsEn
     \fi
     \thesis@blocks@declaration
+    \ifx\thesis@doctoral\thesis@type\thesis@blocks@summary\else\fi
     \thesis@blocks@thanks
 %    \end{macrocode}
 % In KISK theses, the lists of tables and figures will be included


### PR DESCRIPTION
### Description

I have defined the extra key summary for Econ and Phil faculties, in style/mu/econ.dtx and style/mu/phil.dtx respectively. They both are in a conditional statement so they are only added to the doctoral theses. Titles for the summary have also been added to the locales.

Redefinition of abstract, abstractEn has been removed from the econ.dtx.

Merging this pull request closes #6.