### PR TITLE
Adding Summary: Attempt #2

### DIFF
--- a/example/mu/example.dtx
+++ b/example/mu/example.dtx
@@ -149,6 +149,15 @@
 
       span multiple paragraphs.
     },
+    %% The following key is only useful when you are writing a
+    %% doctoral thesis. You can safely omit it in other theses.
+    extra              = {
+      summary          = {%
+        This is the summary of my thesis, which should
+
+	not be very long.
+      },
+    },
 }
 %</econ>
 %<*fi>
@@ -374,6 +383,15 @@
       span multiple paragraphs.
     },
     bib        = example.bib,
+    %% The following key is only useful when you are writing a
+    %% doctoral thesis. You can safely omit it in other theses.
+    extra      = {
+      summary  = {%
+        This is the summary of my thesis, which should
+
+        not be very long.
+      },
+    },
 }
 %</phil>
 %<*sci>

--- a/locale/czech.dtx
+++ b/locale/czech.dtx
@@ -74,6 +74,9 @@
   \fi\fi\fi\fi\fi\fi
   \thesis@year}}
 
+%    \end{macrocode}
+% \changes{v1.0.0}{2021/03/11}{Added title for summary. [TV]}
+%    \begin{macrocode}
 % Různé
 \gdef\thesis@czech@authorSignature{%
   Podpis autor\ifthesis@woman ky\else a\fi}
@@ -84,6 +87,7 @@
 \gdef\thesis@czech@keywordsTitle{Klíčová slova}
 \gdef\thesis@czech@thanksTitle{Poděkování}
 \gdef\thesis@czech@declarationTitle{Prohlášení}
+\gdef\thesis@czech@summaryTitle{Resumé}
 \gdef\thesis@czech@idTitle{ID}
 \gdef\thesis@czech@typeName@sempaper{Seminární práce}
 \gdef\thesis@czech@typeName@bachelors{Bakalářská práce}

--- a/locale/english.dtx
+++ b/locale/english.dtx
@@ -63,6 +63,9 @@
   \fi\fi\fi\fi\fi\fi
   \thesis@year}}
 
+%    \end{macrocode}
+% \changes{v1.0.0}{2021/03/11}{Added title for summary. [TV]}
+%    \begin{macrocode}
 % Miscellaneous
 \gdef\thesis@english@authorSignature{Author's signature}
 \gdef\thesis@english@fieldTitle{Field of study}
@@ -76,6 +79,7 @@
 %    \begin{macrocode}
 \gdef\thesis@english@thanksTitle{Acknowledgements}
 \gdef\thesis@english@declarationTitle{Declaration}
+\gdef\thesis@english@summaryTitle{Summary}
 \gdef\thesis@english@idTitle{ID}
 \gdef\thesis@english@typeName@sempaper{Seminar Paper}
 \gdef\thesis@english@typeName@bachelors{Bachelor's Thesis}

--- a/locale/slovak.dtx
+++ b/locale/slovak.dtx
@@ -74,6 +74,9 @@
   \fi\fi\fi\fi\fi\fi
   \thesis@year}}
 
+%    \end{macrocode}
+% \changes{v1.0.0}{2021/03/11}{Added title for summary. [TV]}
+%    \begin{macrocode}
 % Rôzne
 \gdef\thesis@slovak@authorSignature{%
   Podpis autor\ifthesis@woman ky\else a\fi}
@@ -84,6 +87,7 @@
 \gdef\thesis@slovak@keywordsTitle{Kľúčové slová}
 \gdef\thesis@slovak@thanksTitle{Poďakovanie}
 \gdef\thesis@slovak@declarationTitle{Vyhlásenie}
+\gdef\thesis@slovak@summaryTitle{Resumé}
 \gdef\thesis@slovak@idTitle{ID}
 \gdef\thesis@slovak@typeName@sempaper{Seminárna práca}
 \gdef\thesis@slovak@typeName@bachelors{Bakalárska práca}

--- a/style/mu/base.dtx
+++ b/style/mu/base.dtx
@@ -932,11 +932,13 @@
 % \end{macro}\begin{macro}{\thesis@blocks@abstract}
 % The |\thesis@blocks@abstract| macro typesets the
 % abstract.
+% \changes{v1.0.0}{2021/03/05}{Changed \texttt{clearpage}
+% to \texttt{vskip} so it is by default on the same page
+% when the template contains bibEntry. [TV]}
 % \begin{macrocode}
 \def\thesis@blocks@abstract{%
   \begin{alwayssingle}%
-    % Start the new chapter without clearing the left page.
-    \clearpage
+    \vskip 40 \p@
     {\let\thesis@blocks@clear\relax
     \chapter*{\thesis@@{abstractTitle}}}%
     \noindent\thesis@abstract
@@ -950,13 +952,15 @@
 % \changes{v0.3.46}{2017/06/02}{Simplified the definition of
 %   \cs{thesis@blocks@abstractEn} in
 %   \texttt{style/mu/fithesis-base.sty}. [VN]}
+% \changes{v1.0.0}{2021/03/05}{Changed \texttt{clearpage}
+% to \texttt{vskip} so it is by default on the same page
+% when the template contains bibEntry. [TV]}
 % \begin{macrocode}
 \def\thesis@blocks@abstractEn{%
   \ifthesis@english\else
     {\thesis@selectLocale{english}%
     \begin{alwayssingle}%
-      % Start the new chapter without clearing the left page.
-      \clearpage
+      \vskip 40 \p@
       {\let\thesis@blocks@clear\relax
       \chapter*{\thesis@english@abstractTitle}}%
       \noindent\thesis@abstractEn

--- a/style/mu/econ.dtx
+++ b/style/mu/econ.dtx
@@ -214,41 +214,18 @@
     \end{minipage}}
   \end{alwayssingle}}
 %    \end{macrocode}
-% \end{macro}\begin{macro}{\thesis@blocks@abstract}
+% \end{macro}
 % \changes{v0.3.46}{2017/06/02}{Redefined
 %   \cs{thesis@blocks@abstract}, \cs{thesis@blocks@abstractEn},
 %   \cs{thesis@blocks@keywords}, and \cs{thesis@blocks@keywordsEn}
 %   in \texttt{style/mu/fithesis-econ.sty} in accordance with the
 %   example documents. The patch was submitted by Jana Ratajská.
 %   [VN]}
+% \changes{v1.0.0}{2021/03/11}{Macros for abstract and abstractEn
+%   were moved to \texttt{base.dtx}. [TV]}
 % The |\thesis@blocks@abstract| macro typesets the
 % abstract. This definition typesets the abstract on the same page.
-% \begin{macrocode}
-\def\thesis@blocks@abstract{%
-  \begin{alwayssingle}%
-    \vskip 40\p@
-    {\let\thesis@blocks@clear\relax
-    \chapter*{\thesis@@{abstractTitle}}}%
-    \noindent\thesis@abstract
-  \end{alwayssingle}}
-%    \end{macrocode}
-% \end{macro}\begin{macro}{\thesis@blocks@abstractEn}
-% The |\thesis@blocks@abstractEn| macro typesets the abstract in
-% English. If the current locale is English, the macro produces no
-% output. This macro typesets the abstract on the same page.
-% \begin{macrocode}
-\def\thesis@blocks@abstractEn{%
-  \ifthesis@english\else
-    {\thesis@selectLocale{english}%
-    \begin{alwayssingle}%
-      \vskip 20\p@
-      {\let\thesis@blocks@clear\relax
-      \chapter*{\thesis@english@abstractTitle}}%
-      \noindent\thesis@abstractEn
-    \end{alwayssingle}}%
-  \fi}
-%    \end{macrocode}
-% \end{macro}\begin{macro}{\thesis@blocks@keywords}
+% \begin{macro}{\thesis@blocks@keywords}
 % The |\thesis@blocks@keywords| macro typesets the keywords. This
 % definition typesets the keywords on the same page.
 % \begin{macrocode}

--- a/style/mu/econ.dtx
+++ b/style/mu/econ.dtx
@@ -310,7 +310,26 @@
      \thesis@@{bib@year}:          & \thesis@year       \\
    \end{thesis@newtable@old}}}
 %    \end{macrocode}
+% \end{macro}\begin{macro}{\thesis@blocks@summary}
+% \changes{v1.0.0}{2021/03/11}{Macro for the summary was added. [TV]}
+% The |\thesis@blocks@summary| macro typesets the summary
+% for doctoral theses. If the thesis type is not doctoral, the
+% macro produces no output.
+%    \begin{macrocode}
+\thesis@def@extra[{
+  \thesis@placeholder@extra@summary
+}]{summary}
+
+\def\thesis@blocks@summary{%
+  \begin{alwayssingle}%
+    \thesis@blocks@clear
+    {\let\thesis@blocks@clear\relax
+    \chapter*{\thesis@@{summaryTitle}}}%
+    \noindent\thesis@extra@summary
+  \end{alwayssingle}}
+%    \end{macrocode}
 % \end{macro}
+%
 % Note that there is no direct support for the seminar paper and
 % thesis proposal types.  If you would like to change the contents
 % of the preamble and the postamble, you should modify the
@@ -338,8 +357,11 @@
 % All blocks within the autolayout postamble that are not defined
 % within this file are defined in the \texttt{style/mu/base.sty}
 % file.
+% \changes{v1.0.0}{2021/03/11}{Added conditional to include summary
+% in doctoral theses. [TV]}
 %    \begin{macrocode}
 \def\thesis@blocks@postamble{%
+  \ifx\thesis@doctoral\thesis@type\thesis@blocks@summary\else\fi
   \thesis@blocks@bibliography
   \thesis@blocks@tables}
 %    \end{macrocode}

--- a/style/mu/phil.dtx
+++ b/style/mu/phil.dtx
@@ -70,7 +70,26 @@
   {\thesis@titlePage@large\\[0.3in]
     {\bf\thesis@@{advisorTitle}:} \thesis@advisor}}
 %    \end{macrocode}
+% \end{macro}\begin{macro}{\thesis@blocks@summary}
+% \changes{v1.0.0}{2021/03/11}{Macro for the summary was added. [TV]}
+% The |\thesis@blocks@summary| macro typesets the summary
+% for doctoral theses. If the thesis type is not doctoral, the
+% macro produces no output.
+%    \begin{macrocode}
+\thesis@def@extra[{
+  \thesis@placeholder@extra@summary
+}]{summary}
+
+\def\thesis@blocks@summary{%
+  \begin{alwayssingle}%
+    \thesis@blocks@clear
+    {\let\thesis@blocks@clear\relax
+    \chapter*{\thesis@@{summaryTitle}}}%
+    \noindent\thesis@extra@summary
+    \end{alwayssingle}}
+%    \end{macrocode}
 % \end{macro}
+%
 % Note that there is no direct support for the seminar paper and
 % thesis proposal types.  If you would like to change the contents
 % of the preamble and the postamble, you should modify the
@@ -88,6 +107,8 @@
 %    \end{macrocode}
 % In KISK theses, the bibliographical entry, the abstract, and the
 % keywords will be included after the cover matter.
+% \changes{v1.0.0}{2021/03/11}{Added conditional to add summary for
+% doctoral theses. [TV]}
 %    \begin{macrocode}
     \ifx\thesis@department\thesis@departments@kisk
       \thesis@blocks@bibEntry
@@ -97,6 +118,7 @@
       \thesis@blocks@keywordsEn
     \fi
     \thesis@blocks@declaration
+    \ifx\thesis@doctoral\thesis@type\thesis@blocks@summary\else\fi
     \thesis@blocks@thanks
 %    \end{macrocode}
 % In KISK theses, the lists of tables and figures will be included


### PR DESCRIPTION
I have defined the extra key summary for Econ and Phil faculties, in style/mu/econ.dtx and style/mu/phil.dtx respectively. They both are in a conditional statement so they are only added to the doctoral theses. Titles for the summary have also been added to the locales.

Redefinition of abstract, abstractEn has been removed from the econ.dtx.

New pull request because v2 had merging issues.

Merging this pull request closes #6.