### PR TITLE
Dictionary/Abbreviations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ MAKES=guide/mu/Makefile guide/mu/resources/Makefile \
 	style/mu/Makefile test/Makefile test/mu/blind/Makefile \
 	test/mu/compare/Makefile test/mu/compare-example/Makefile
 USEREXAMPLE_SOURCES=example/mu/Makefile example/mu/example.dtx \
-	example/mu/*.ins example/mu/latexmkrc
+	example/mu/*.ins example/mu/latexmkrc \
+	example/mu/example-terms-abbrs.tex
 USEREXAMPLES=example/mu/econ-lualatex.pdf \
 	example/mu/econ-pdflatex.pdf example/mu/fi-lualatex.pdf \
 	example/mu/fi-pdflatex.pdf example/mu/fsps-lualatex.pdf \

--- a/example/mu/Makefile
+++ b/example/mu/Makefile
@@ -21,7 +21,7 @@ all: $(OUTPUT) clean
 		$(patsubst %-pdflatex.tex,%-,$(subst lua,pdf,$@))*.tex
 
 # This target typesets a pdfLaTeX example.
-%-pdflatex.pdf: %-pdflatex.tex example.bib
+%-pdflatex.pdf: %-pdflatex.tex example.bib example-terms-abbrs.tex
 	$(PDFLATEX) $< # The initial typesetting.
 	biber                               $(basename $<).bcf
 	$(PDFLATEX) $< # Update the index after the bibliography insertion.
@@ -30,7 +30,7 @@ all: $(OUTPUT) clean
 	$(PDFLATEX) $<
 
 # This target typesets a LuaLaTeX example.
-%-lualatex.pdf: %-lualatex.tex example.bib
+%-lualatex.pdf: %-lualatex.tex example.bib example-terms-abbrs.tex
 	$(LUALATEX) $< # The initial typesetting.
 	biber                               $(basename $<).bcf
 	$(LUALATEX) $< # Update the index after the bibliography insertion.

--- a/example/mu/example-terms-abbrs.tex
+++ b/example/mu/example-terms-abbrs.tex
@@ -1,0 +1,12 @@
+% These are examples for entries in Dictionary of Terms 
+% and List of Abbreviations
+
+% Example of Dictionary entry
+\newglossary{Overleaf}
+{
+    name=Overleaf,
+    description={is an online service for working with LaTex files.}
+}
+
+% Example of LoA entry
+\newacronym{MUNI}{MUNI}{Masaryk University}

--- a/example/mu/example-terms-abbrs.tex
+++ b/example/mu/example-terms-abbrs.tex
@@ -2,7 +2,7 @@
 % and List of Abbreviations
 
 % Example of Dictionary entry
-\newglossary{Overleaf}
+\newglossaryentry{Overleaf}
 {
     name=Overleaf,
     description={is an online service for working with LaTex files.}

--- a/example/mu/example.dtx
+++ b/example/mu/example.dtx
@@ -905,7 +905,7 @@ proofs.
 %<*econ>
   \emph{Source: <<Image Source>>}
 %</econ>
-  \caption{The logo of the Masaryk University at $\frac23$ and
+	\caption{The logo of the \arclong{MUNI} at $\frac23$ and
     $\frac13$ of text width}
   \label{fig:mulogo2}
 \end{figure}
@@ -967,7 +967,7 @@ run of
 \texttt{lualatex \jobname.tex}
 %</luatex>
 and a second run is going to be needed for the references to
-resolve. With online services -- such as Overleaf -- this is
+resolve. With online services -- such as \Gls{Overleaf} -- this is
 performed automatically.
 
 \chapter{Mathematical equations}

--- a/example/mu/example.dtx
+++ b/example/mu/example.dtx
@@ -584,8 +584,8 @@
 %% document. Titles for these tables can be changed by replacing the
 %% titles `Abbreviations` and `Dictionary`, respectively.
 
-%% \printglossary[title={Abbreviations}, type=\acronymtype]
-%% \printglossary[title={Dictionary}]
+\printglossary[title={Abbreviations}, type=\acronymtype]
+\printglossary[title={Dictionary}]
 
 \chapter*{Introduction}
 \addcontentsline{toc}{chapter}{Introduction}

--- a/example/mu/example.dtx
+++ b/example/mu/example.dtx
@@ -519,7 +519,7 @@
 \usepackage[acronym]{glossaries}          %% The `glossaries` package
 \renewcommand*\glspostdescription{\hfill} %% contains helper commands
 \loadglsentries{example-terms-abbrs.tex}  %% for dict and loa
-\makeglossaries                           %% typesetting.
+\makenoidxglossaries                      %% typesetting.
 %% These additional packages are used within the document:
 \usepackage{paralist} %% Compact list environments
 \usepackage{amsmath}  %% Mathematics
@@ -553,7 +553,7 @@
 
 %</econ>
 %    \end{macrocode}
-% \changes{v1.0.0}{2021/03/22}{Added \cs{printglossary} to print out
+% \changes{v1.0.0}{2021/03/22}{Added \cs{printnoidxglossary} to print
 %   Dictionary and List of Abbreviations. [TV]}
 %    \begin{macrocode}
 %% Uncomment the following lines (by removing the %% at the beginning)
@@ -561,8 +561,8 @@
 %% document. Titles for these tables can be changed by replacing the
 %% titles `Abbreviations` and `Dictionary`, respectively.
 \clearpage
-\printglossary[title={Abbreviations}, type=\acronymtype]
-\printglossary[title={Dictionary}]
+\printnoidxglossary[title={Abbreviations}, type=\acronymtype]
+\printnoidxglossary[title={Dictionary}]
 
 \chapter*{Introduction}
 \addcontentsline{toc}{chapter}{Introduction}
@@ -905,7 +905,7 @@ proofs.
 %<*econ>
   \emph{Source: <<Image Source>>}
 %</econ>
-	\caption{The logo of the \arclong{MUNI} at $\frac23$ and
+	\caption{The logo of the \acrlong{MUNI} at $\frac23$ and
     $\frac13$ of text width}
   \label{fig:mulogo2}
 \end{figure}

--- a/example/mu/example.dtx
+++ b/example/mu/example.dtx
@@ -102,8 +102,6 @@
 % \changes{v1.0.0}{2021/03/04}{Added elements that are used 
 %   by thesis@bibEntry and thesis@titlePage: field, fieldEn
 %   departmentEn. [TV]}
-% \changes{v1.0.0}{2021/03/22}{Added key dict for printing
-%   glossaries. [TV]}
 %    \begin{macrocode}
 
 \thesissetup{
@@ -136,7 +134,6 @@
       span multiple paragraphs.
     },
     bib                = example.bib,
-    dict               = example-terms-abbrs.tex,
     %% Uncomment the following line (by removing the %% at the
     %% beginning) and replace `assignment.pdf` with the filename
     %% of your scanned thesis assignment.
@@ -170,8 +167,6 @@
 %    \end{macrocode}
 % \changes{v1.0.0}{2021/03/04}{Added elements that are used
 %   by thesis@titlePage: field, department. [TV]}
-% \changes{v1.0.0}{2021/03/22}{Added key dict for printing
-%   glossaries. [TV]}
 %    \begin{macrocode}
 \thesissetup{
     date        = \the\year/\the\month/\the\day,
@@ -198,7 +193,6 @@
       span multiple paragraphs.
     },
     bib         = example.bib,
-    dict        = example-terms-abbrs.tex,
     %% Uncomment the following line (by removing the %% at the
     %% beginning) and replace `assignment.pdf` with the filename
     %% of your scanned thesis assignment.
@@ -211,8 +205,6 @@
 %   by thesis@bibEntry and thesis@titlePage: field, fieldEn,
 %   department, departmentEn, titleEn, TeXtitleEn, keywords, 
 %   keywordsEn, TeXkeywords, TeXkeywordsEn. [TV]}
-% \changes{v1.0.0}{2021/03/22}{Added key dict for printing
-%   glossaries. [TV]}
 %    \begin{macrocode}
 \thesissetup{
     date          = \the\year/\the\month/\the\day,
@@ -231,7 +223,6 @@
     keywords      = {keyword1, keywords2, ...},
     TeXkeywords   = {keyword1, keywords2, \ldots},
     bib           = example.bib,
-    dict          = example-terms-abbrs.tex,
     %% The following keys are only useful, when you're using a
     %% locale other than English. You can safely omit them in an
     %% English thesis.
@@ -248,8 +239,6 @@
 % \changes{v1.0.0}{2021/03/04}{Added elements that are used
 %   by thesis@bibEntry and thesis@titlePage: field, fieldEn,
 %   department, departmentEn, titleEn, TeXtitleEn. [TV]}
-% \changes{v1.0.0}{2021/03/22}{Added key dict for printing
-%   glossaries. [TV]}
 %    \begin{macrocode}
 \thesissetup{
     date          = \the\year/\the\month/\the\day,
@@ -277,7 +266,6 @@
       span multiple paragraphs.
     },
     bib           = example.bib,
-    dict          = example-terms-abbrs.tex,
     %% The following keys are only useful, when you're using a
     %% locale other than English. You can safely omit them in an
     %% English thesis.
@@ -300,8 +288,6 @@
 %    \end{macrocode}
 % \changes{v1.0.0}{2021/03/04}{Added elements that are used
 %   by thesis@titlePage: field [TV]}
-% \changes{v1.0.0}{2021/03/22}{Added key dict for printing
-%   glossaries. [TV]}
 %    \begin{macrocode}
 \thesissetup{
     date          = \the\year/\the\month/\the\day,
@@ -329,7 +315,6 @@
       span multiple paragraphs.
     },
     bib           = example.bib,
-    dict          = example-terms-abbrs.tex,
     %% The following keys are only useful, when you're using a
     %% locale other than English. You can safely omit them in an
     %% English thesis.
@@ -343,10 +328,6 @@
 }
 %</law>
 %<*med>
-%    \end{macrocode}
-% \changes{v1.0.0}{2021/03/22}{Added key dict for printing
-%   glossaries. [TV]}
-%    \begin{macrocode}
 \thesissetup{
     date          = \the\year/\the\month/\the\day,
     university    = mu,
@@ -375,7 +356,6 @@
       span multiple paragraphs.
     },
     bib           = example.bib,
-    dict          = example-terms-abbrs.tex,
     %% The following keys are only useful, when you're using a
     %% locale other than English. You can safely omit them in an
     %% English thesis.
@@ -393,8 +373,6 @@
 % \changes{v1.0.0}{2021/03/04}{Added elements that are used
 %   by thesis@bibEntry and thesis@titlePage: field, fieldEn,
 %   departmentEn, titleEn, TeXtitleEn. [TV]}
-% \changes{v1.0.0}{2021/03/22}{Added key dict for printing
-%   glossaries. [TV]}
 %    \begin{macrocode}
 \thesissetup{
     date          = \the\year/\the\month/\the\day,
@@ -423,7 +401,6 @@
       span multiple paragraphs.
     },
     bib           = example.bib,
-    dict          = example-terms-abbrs.tex,
     %% The following keys are only useful, when you're using a
     %% locale other than English. You can safely omit them in an
     %% English thesis.
@@ -447,8 +424,6 @@
 % \changes{v1.0.0}{2021/03/04}{Added elements that are used
 %   by thesis@bibEntry and thesis@titlePage: fieldEn, departmentEn,
 %   titleEn, TeXtitleEn, keywordsEn, TeXkeywordsEn, abstractEn. [TV]}
-% \changes{v1.0.0}{2021/03/22}{Added key dict for printing
-%   glossaries. [TV]}
 %    \begin{macrocode}
 \thesissetup{
     date        = \the\year/\the\month/\the\day,
@@ -472,7 +447,6 @@
       span multiple paragraphs.
     },
     bib        = example.bib,
-    dict       = example-terms-abbrs.tex,
     %% The following keys are only useful, when you're using a
     %% locale other than English. You can safely omit them in an
     %% English thesis.
@@ -501,10 +475,6 @@
 }
 %</phil>
 %<*sci>
-%    \end{macrocode}
-% \changes{v1.0.0}{2021/03/22}{Added key dict for printing
-%   glossaries. [TV]}
-%    \begin{macrocode}
 \thesissetup{
     date            = \the\year/\the\month/\the\day,
     university      = mu,
@@ -534,15 +504,22 @@
       span multiple paragraphs.
     },
     bib           = example.bib,
-    dict          = example-terms-abbrs.tex,
     %% Uncomment the following line (by removing the %% at the
     %% beginning) and replace `assignment.pdf` with the filename
     %% of your scanned thesis assignment.
 %%    assignment         = assignment.pdf,
 }
 %</sci>
+%    \end{macrocode}
+% \changes{v1.0.0}{2021/03/22}{Added \textsf{glossaries} package.
+%    [TV]}
+%    \begin{macrocode}
 \usepackage{makeidx}      %% The `makeidx` package contains
 \makeindex                %% helper commands for index typesetting.
+\usepackage[acronym]{glossaries}          %% The `glossaries` package
+\nenewcommand*\glspostdescription{\hfill} %% contains helper commands
+\makeglossaries                           %% for dict and loa
+\input{example-terms-abbrv}               %% typesetting.
 %% These additional packages are used within the document:
 \usepackage{paralist} %% Compact list environments
 \usepackage{amsmath}  %% Mathematics
@@ -583,7 +560,7 @@
 %% and to print out List of Abbreviations and/or Dictionary in your
 %% document. Titles for these tables can be changed by replacing the
 %% titles `Abbreviations` and `Dictionary`, respectively.
-
+\clearpage
 \printglossary[title={Abbreviations}, type=\acronymtype]
 \printglossary[title={Dictionary}]
 

--- a/example/mu/example.dtx
+++ b/example/mu/example.dtx
@@ -247,10 +247,9 @@
 %    \end{macrocode}
 % \changes{v1.0.0}{2021/03/04}{Added elements that are used
 %   by thesis@bibEntry and thesis@titlePage: field, fieldEn,
-%   department, departmentEn, titleEn, TeXtitleEn. [TV]
+%   department, departmentEn, titleEn, TeXtitleEn. [TV]}
 % \changes{v1.0.0}{2021/03/22}{Added key dict for printing
 %   glossaries. [TV]}
-}
 %    \begin{macrocode}
 \thesissetup{
     date          = \the\year/\the\month/\the\day,

--- a/example/mu/example.dtx
+++ b/example/mu/example.dtx
@@ -517,7 +517,7 @@
 \usepackage{makeidx}      %% The `makeidx` package contains
 \makeindex                %% helper commands for index typesetting.
 \usepackage[acronym]{glossaries}          %% The `glossaries` package
-\nenewcommand*\glspostdescription{\hfill} %% contains helper commands
+\renewcommand*\glspostdescription{\hfill} %% contains helper commands
 \makeglossaries                           %% for dict and loa
 \input{example-terms-abbrv}               %% typesetting.
 %% These additional packages are used within the document:

--- a/example/mu/example.dtx
+++ b/example/mu/example.dtx
@@ -560,9 +560,9 @@
 %% and to print out List of Abbreviations and/or Dictionary in your
 %% document. Titles for these tables can be changed by replacing the
 %% titles `Abbreviations` and `Dictionary`, respectively.
-\clearpage
-\printnoidxglossary[title={Abbreviations}, type=\acronymtype]
-\printnoidxglossary[title={Dictionary}]
+%% \clearpage
+%% \printnoidxglossary[title={Abbreviations}, type=\acronymtype]
+%% \printnoidxglossary[title={Dictionary}]
 
 \chapter*{Introduction}
 \addcontentsline{toc}{chapter}{Introduction}

--- a/example/mu/example.dtx
+++ b/example/mu/example.dtx
@@ -544,6 +544,17 @@
 \makeatother
 
 %</econ>
+%    \end{macrocode}
+% \changes{v1.0.0}{2021/03/22}{Added \cs{printglossary} to print out
+%   Dictionary and List of Abbreviations. [TV]}
+%    \begin{macrocode}
+%% Uncomment the following lines (by removing the %% at the beginning)
+%% and to print out List of Abbreviations and/or Dictionary in your
+%% document. Titles for these tables can be changed by replacing the
+%% titles `Abbreviations` and `Dictionary`, respectively.
+
+%% \printglossary[title={Abbreviations}, type=\acronymtype]
+%% \printglossary[title={Dictionary}]
 \chapter*{Introduction}
 \addcontentsline{toc}{chapter}{Introduction}
 

--- a/example/mu/example.dtx
+++ b/example/mu/example.dtx
@@ -519,7 +519,7 @@
 \usepackage[acronym]{glossaries}          %% The `glossaries` package
 \renewcommand*\glspostdescription{\hfill} %% contains helper commands
 \makeglossaries                           %% for dict and loa
-\input{example-terms-abbrv}               %% typesetting.
+\input{example-terms-abbrs}               %% typesetting.
 %% These additional packages are used within the document:
 \usepackage{paralist} %% Compact list environments
 \usepackage{amsmath}  %% Mathematics

--- a/example/mu/example.dtx
+++ b/example/mu/example.dtx
@@ -102,6 +102,8 @@
 % \changes{v1.0.0}{2021/03/04}{Added elements that are used 
 %   by thesis@bibEntry and thesis@titlePage: field, fieldEn
 %   departmentEn. [TV]}
+% \changes{v1.0.0}{2021/03/22}{Added key dict for printing
+%   glossaries. [TV]}
 %    \begin{macrocode}
 
 \thesissetup{
@@ -134,6 +136,7 @@
       span multiple paragraphs.
     },
     bib                = example.bib,
+    dict               = example-terms-abbrs.tex,
     %% Uncomment the following line (by removing the %% at the
     %% beginning) and replace `assignment.pdf` with the filename
     %% of your scanned thesis assignment.
@@ -167,6 +170,8 @@
 %    \end{macrocode}
 % \changes{v1.0.0}{2021/03/04}{Added elements that are used
 %   by thesis@titlePage: field, department. [TV]}
+% \changes{v1.0.0}{2021/03/22}{Added key dict for printing
+%   glossaries. [TV]}
 %    \begin{macrocode}
 \thesissetup{
     date        = \the\year/\the\month/\the\day,
@@ -193,6 +198,7 @@
       span multiple paragraphs.
     },
     bib         = example.bib,
+    dict        = example-terms-abbrs.tex,
     %% Uncomment the following line (by removing the %% at the
     %% beginning) and replace `assignment.pdf` with the filename
     %% of your scanned thesis assignment.
@@ -205,6 +211,8 @@
 %   by thesis@bibEntry and thesis@titlePage: field, fieldEn,
 %   department, departmentEn, titleEn, TeXtitleEn, keywords, 
 %   keywordsEn, TeXkeywords, TeXkeywordsEn. [TV]}
+% \changes{v1.0.0}{2021/03/22}{Added key dict for printing
+%   glossaries. [TV]}
 %    \begin{macrocode}
 \thesissetup{
     date          = \the\year/\the\month/\the\day,
@@ -223,6 +231,7 @@
     keywords      = {keyword1, keywords2, ...},
     TeXkeywords   = {keyword1, keywords2, \ldots},
     bib           = example.bib,
+    dict          = example-terms-abbrs.tex,
     %% The following keys are only useful, when you're using a
     %% locale other than English. You can safely omit them in an
     %% English thesis.
@@ -238,7 +247,10 @@
 %    \end{macrocode}
 % \changes{v1.0.0}{2021/03/04}{Added elements that are used
 %   by thesis@bibEntry and thesis@titlePage: field, fieldEn,
-%   department, departmentEn, titleEn, TeXtitleEn. [TV]}
+%   department, departmentEn, titleEn, TeXtitleEn. [TV]
+% \changes{v1.0.0}{2021/03/22}{Added key dict for printing
+%   glossaries. [TV]}
+}
 %    \begin{macrocode}
 \thesissetup{
     date          = \the\year/\the\month/\the\day,
@@ -266,6 +278,7 @@
       span multiple paragraphs.
     },
     bib           = example.bib,
+    dict          = example-terms-abbrs.tex,
     %% The following keys are only useful, when you're using a
     %% locale other than English. You can safely omit them in an
     %% English thesis.
@@ -288,6 +301,8 @@
 %    \end{macrocode}
 % \changes{v1.0.0}{2021/03/04}{Added elements that are used
 %   by thesis@titlePage: field [TV]}
+% \changes{v1.0.0}{2021/03/22}{Added key dict for printing
+%   glossaries. [TV]}
 %    \begin{macrocode}
 \thesissetup{
     date          = \the\year/\the\month/\the\day,
@@ -315,6 +330,7 @@
       span multiple paragraphs.
     },
     bib           = example.bib,
+    dict          = example-terms-abbrs.tex,
     %% The following keys are only useful, when you're using a
     %% locale other than English. You can safely omit them in an
     %% English thesis.
@@ -328,6 +344,10 @@
 }
 %</law>
 %<*med>
+%    \end{macrocode}
+% \changes{v1.0.0}{2021/03/22}{Added key dict for printing
+%   glossaries. [TV]}
+%    \begin{macrocode}
 \thesissetup{
     date          = \the\year/\the\month/\the\day,
     university    = mu,
@@ -356,6 +376,7 @@
       span multiple paragraphs.
     },
     bib           = example.bib,
+    dict          = example-terms-abbrs.tex,
     %% The following keys are only useful, when you're using a
     %% locale other than English. You can safely omit them in an
     %% English thesis.
@@ -373,6 +394,8 @@
 % \changes{v1.0.0}{2021/03/04}{Added elements that are used
 %   by thesis@bibEntry and thesis@titlePage: field, fieldEn,
 %   departmentEn, titleEn, TeXtitleEn. [TV]}
+% \changes{v1.0.0}{2021/03/22}{Added key dict for printing
+%   glossaries. [TV]}
 %    \begin{macrocode}
 \thesissetup{
     date          = \the\year/\the\month/\the\day,
@@ -401,6 +424,7 @@
       span multiple paragraphs.
     },
     bib           = example.bib,
+    dict          = example-terms-abbrs.tex,
     %% The following keys are only useful, when you're using a
     %% locale other than English. You can safely omit them in an
     %% English thesis.
@@ -424,6 +448,8 @@
 % \changes{v1.0.0}{2021/03/04}{Added elements that are used
 %   by thesis@bibEntry and thesis@titlePage: fieldEn, departmentEn,
 %   titleEn, TeXtitleEn, keywordsEn, TeXkeywordsEn, abstractEn. [TV]}
+% \changes{v1.0.0}{2021/03/22}{Added key dict for printing
+%   glossaries. [TV]}
 %    \begin{macrocode}
 \thesissetup{
     date        = \the\year/\the\month/\the\day,
@@ -447,6 +473,7 @@
       span multiple paragraphs.
     },
     bib        = example.bib,
+    dict       = example-terms-abbrs.tex,
     %% The following keys are only useful, when you're using a
     %% locale other than English. You can safely omit them in an
     %% English thesis.
@@ -475,6 +502,10 @@
 }
 %</phil>
 %<*sci>
+%    \end{macrocode}
+% \changes{v1.0.0}{2021/03/22}{Added key dict for printing
+%   glossaries. [TV]}
+%    \begin{macrocode}
 \thesissetup{
     date            = \the\year/\the\month/\the\day,
     university      = mu,
@@ -504,6 +535,7 @@
       span multiple paragraphs.
     },
     bib           = example.bib,
+    dict          = example-terms-abbrs.tex,
     %% Uncomment the following line (by removing the %% at the
     %% beginning) and replace `assignment.pdf` with the filename
     %% of your scanned thesis assignment.
@@ -555,6 +587,7 @@
 
 %% \printglossary[title={Abbreviations}, type=\acronymtype]
 %% \printglossary[title={Dictionary}]
+
 \chapter*{Introduction}
 \addcontentsline{toc}{chapter}{Introduction}
 

--- a/example/mu/example.dtx
+++ b/example/mu/example.dtx
@@ -518,8 +518,8 @@
 \makeindex                %% helper commands for index typesetting.
 \usepackage[acronym]{glossaries}          %% The `glossaries` package
 \renewcommand*\glspostdescription{\hfill} %% contains helper commands
-\makeglossaries                           %% for dict and loa
-\input{example-terms-abbrs}               %% typesetting.
+\loadglsentries{example-terms-abbrs.tex}  %% for dict and loa
+\makeglossaries                           %% typesetting.
 %% These additional packages are used within the document:
 \usepackage{paralist} %% Compact list environments
 \usepackage{amsmath}  %% Mathematics

--- a/fithesis.dtx
+++ b/fithesis.dtx
@@ -20,6 +20,7 @@
 \usepackage{multicol}
 \usepackage[acronym]{glossaries}
 
+
 % Making paragraphs numbered
 \makeatletter
 \renewcommand\paragraph{\@startsection{paragraph}{4}{\z@}%
@@ -29,6 +30,13 @@
 \makeatother
 \setcounter{secnumdepth}{4} % how many sectioning levels to assign
 \setcounter{tocdepth}{4}    % how many sectioning levels to show
+
+% Aligning page numbers of occurences of terms and abbreviation
+% to the right
+\makeatletter
+\renewcommand*\glspostdescription{\hfill}
+\makeatother
+\makeglossaries
 
 % ltxdoc class options
 \CodelineIndex
@@ -1277,6 +1285,22 @@
 % When the |\thesis@bibFiles| macro is defined and non-empty, the
 % style files should take that as a cue that the user wishes to
 % typeset the bibliography.
+% \changes{v1.0.0}{2021/03/22}{Added \texttt{dict} key for printing
+%   glossaries. [TV]}
+% \begin{macro}{\thesis@dictFiles}
+% \subsubsection{The \texttt{dict} key}
+% The \marg{\texttt{dict}=list} pair sets the comma-delimited
+% list of paths to the TeX files containing the Dictionary and
+% List of Abbreviations databases to \textit{list}. The \textit{list}
+% is stored within the |\thesis@dictFiles| macro.
+%    \begin{macrocode}
+\define@key{thesis@dict}{%
+  \def\thesis@dictFiles{#1}}
+%    \end{macrocode}
+% \end{macro}
+% When the |\thesis@dictFiles| macro is defined and non-empty, the
+% style files should take that as a cue that the user wishes to
+% typeset the dictionary and list of abbreviations.
 % \begin{macro}{\ifthesis@auto}
 % \subsubsection{The \texttt{autoLayout} key}
 % The \marg{\texttt{autoLayout}=bool} pair either enables,

--- a/fithesis.dtx
+++ b/fithesis.dtx
@@ -18,6 +18,7 @@
 \usepackage{ragged2e}
 \usepackage{paralist}
 \usepackage{multicol}
+\usepackage[acronym]{glossaries}
 
 % Making paragraphs numbered
 \makeatletter
@@ -61,6 +62,8 @@
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
+% \changes{v1.0.0}{2021/03/22}{Added package glossaries for printing
+%   out Dictionary and List of Abbreviations. [TV]}
 % ^^A Since 0.3.45, all changes are documented at the change sites.
 % \changes{v0.3.44}  {2017/05/18}{Fixed the color in the logo of FI
 %   MU. [VN]}

--- a/fithesis.dtx
+++ b/fithesis.dtx
@@ -1271,6 +1271,7 @@
 % When the |\thesis@assignmentFiles| macro is defined and
 % non-empty, the style files should take that as a cue that the
 % user wishes to typeset the thesis assignment.
+
 % \begin{macro}{\thesis@bibFiles}
 % \subsubsection{The \texttt{bib} key}
 % The \marg{\texttt{bib}=list} pair sets the comma-delimited
@@ -1285,6 +1286,7 @@
 % When the |\thesis@bibFiles| macro is defined and non-empty, the
 % style files should take that as a cue that the user wishes to
 % typeset the bibliography.
+
 % \changes{v1.0.0}{2021/03/22}{Added \texttt{dict} key for printing
 %   glossaries. [TV]}
 % \begin{macro}{\thesis@dictFiles}
@@ -1294,13 +1296,14 @@
 % List of Abbreviations databases to \textit{list}. The \textit{list}
 % is stored within the |\thesis@dictFiles| macro.
 %    \begin{macrocode}
-\define@key{thesis@dict}{%
+\define@key{thesis}{dict}{%
   \def\thesis@dictFiles{#1}}
 %    \end{macrocode}
 % \end{macro}
 % When the |\thesis@dictFiles| macro is defined and non-empty, the
 % style files should take that as a cue that the user wishes to
 % typeset the dictionary and list of abbreviations.
+
 % \begin{macro}{\ifthesis@auto}
 % \subsubsection{The \texttt{autoLayout} key}
 % The \marg{\texttt{autoLayout}=bool} pair either enables,

--- a/fithesis.dtx
+++ b/fithesis.dtx
@@ -18,7 +18,6 @@
 \usepackage{ragged2e}
 \usepackage{paralist}
 \usepackage{multicol}
-\usepackage[acronym]{glossaries}
 
 
 % Making paragraphs numbered
@@ -30,13 +29,6 @@
 \makeatother
 \setcounter{secnumdepth}{4} % how many sectioning levels to assign
 \setcounter{tocdepth}{4}    % how many sectioning levels to show
-
-% Aligning page numbers of occurences of terms and abbreviation
-% to the right
-\makeatletter
-\renewcommand*\glspostdescription{\hfill}
-\makeatother
-\makeglossaries
 
 % ltxdoc class options
 \CodelineIndex
@@ -70,8 +62,6 @@
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
-% \changes{v1.0.0}{2021/03/22}{Added package glossaries for printing
-%   out Dictionary and List of Abbreviations. [TV]}
 % ^^A Since 0.3.45, all changes are documented at the change sites.
 % \changes{v0.3.44}  {2017/05/18}{Fixed the color in the logo of FI
 %   MU. [VN]}
@@ -1286,22 +1276,6 @@
 % When the |\thesis@bibFiles| macro is defined and non-empty, the
 % style files should take that as a cue that the user wishes to
 % typeset the bibliography.
-% \changes{v1.0.0}{2021/03/22}{Added \texttt{dict} key for printing
-%   glossaries. [TV]}
-% \begin{macro}{\thesis@dictFiles}
-% \subsubsection{The \texttt{dict} key}
-% The \marg{\texttt{dict}=list} pair sets the comma-delimited
-% list of paths to the TeX files containing the Dictionary and
-% List of Abbreviations databases to \textit{list}. The \textit{list}
-% is stored within the |\thesis@dictFiles| macro.
-%    \begin{macrocode}
-\define@key{thesis}{dict}{%
-  \def\thesis@dictFiles{#1}}
-%    \end{macrocode}
-% \end{macro}
-% When the |\thesis@dictFiles| macro is defined and non-empty, the
-% style files should take that as a cue that the user wishes to
-% typeset the dictionary and list of abbreviations.
 % \begin{macro}{\ifthesis@auto}
 % \subsubsection{The \texttt{autoLayout} key}
 % The \marg{\texttt{autoLayout}=bool} pair either enables,

--- a/fithesis.dtx
+++ b/fithesis.dtx
@@ -1286,7 +1286,6 @@
 % When the |\thesis@bibFiles| macro is defined and non-empty, the
 % style files should take that as a cue that the user wishes to
 % typeset the bibliography.
-
 % \changes{v1.0.0}{2021/03/22}{Added \texttt{dict} key for printing
 %   glossaries. [TV]}
 % \begin{macro}{\thesis@dictFiles}
@@ -1303,7 +1302,6 @@
 % When the |\thesis@dictFiles| macro is defined and non-empty, the
 % style files should take that as a cue that the user wishes to
 % typeset the dictionary and list of abbreviations.
-
 % \begin{macro}{\ifthesis@auto}
 % \subsubsection{The \texttt{autoLayout} key}
 % The \marg{\texttt{autoLayout}=bool} pair either enables,


### PR DESCRIPTION
I have added the glossaries package and the file example-terms-abbrv.tex, to which users can put the entries for Dictionary and List of Abbreviations.

Currently, the .tex file does not have a key in \thesissetup like bib does. It may be implemented that way in the future. Some additional explanation to the usage of \Gls and \acrlong may also be added.

This pull request closes issue #3.