### PR TITLE
Redefined title page conditionals for econ, fi, fss, law, med, and sci

### DIFF
--- a/style/mu/base.dtx
+++ b/style/mu/base.dtx
@@ -869,13 +869,13 @@
       \thesis@blocks@universityLogo@color
       \par\vspace{0.75cm}%
       {\sf\thesis@titlePage@large\thesis@@upper{facultyName}}%
-      \par\vspace{1.75cm}%
-      {\bf\thesis@titlePage@Huge\thesis@TeXtitle}%
-      \par\vspace{1.75cm}%
-      {\sf\thesis@titlePage@Large\thesis@@{typeName}}
       \par\vfill
+      {\bf\thesis@titlePage@Huge\thesis@TeXtitle}%
+      \par\vspace{1.5cm}%
+      {\sf\thesis@titlePage@Large\thesis@@{typeName}}
+      \par\vspace{1.5cm}
       {\sf\thesis@titlePage@LARGE\thesis@upper{author}}%
-      \par\vfill\vfill
+      \par\vfill
       {\sf\thesis@titlePage@large\thesis@@{advisorTitle}: \thesis@advisor}%
       \par\vspace{0.75cm}%
       \ifthesis@blocks@titlePage@department@

--- a/style/mu/econ.dtx
+++ b/style/mu/econ.dtx
@@ -75,6 +75,11 @@
 % \changes{v1.0.0}{2021/04/23}{^^A
 %   The style files for the Faculty of Economics and Administration
 %   no longer redefine the \cs{thesis@blocks@cover}. [TV]}    
+% \changes{v1.0.0}{2021/05/06}{Added redefinition of the conditional
+%   to exclude the study field from the title page. [TV]}
+%    \begin{macrocode}
+\thesis@blocks@titlePage@field@false
+%    \end{macrocode}
 % \begin{macro}{\thesis@blocks@frontMatter}
 % The |\thesis@blocks@frontMatter| macro sets up the style
 % of the front matter of the thesis. The page numbering is arabic

--- a/style/mu/fi.dtx
+++ b/style/mu/fi.dtx
@@ -69,6 +69,13 @@
   \end{alwayssingle}}
 %    \end{macrocode}
 % \end{macro}
+% \changes{v1.0.0}{2021/05/06}{Added redefinition of conditionals
+%    to exclude the study field and the study programme from the
+  %    title page. [TV]}
+%    \begin{macrocode}
+\thesis@blocks@titlePage@field@false
+\thesis@blocks@titlePage@programme@false
+%    \end{macrocode}
 % In Ph.D. theses, only the table of contents will be typeset in
 % the front matter as per the formal requirements of the
 % faculty\footnote{See

--- a/style/mu/fss.dtx
+++ b/style/mu/fss.dtx
@@ -31,6 +31,11 @@
   sorting=nty}
 \thesis@bibliography@load
 %    \end{macrocode}
+% \changes{v1.0.0}{2021/05/06}{Added redefinition of the conditional
+%    to exclude the study field from the title page. [TV]}
+%    \begin{macrocode}
+\thesis@blocks@titlePage@field@false
+%    \end{macrocode}
 % \begin{macro}{\thesis@blocks@frontMatter}
 % The |\thesis@blocks@frontMatter| macro sets up the style
 % of the front matter of the thesis.

--- a/style/mu/law.dtx
+++ b/style/mu/law.dtx
@@ -45,6 +45,8 @@
 % The style file configures the upper part of the title page headers
 % to include the name of the department and the study field
 % which are by default in the bottom part of the title page.
+% \changes{v1.0.0}{2021/05/06}{Added conditional redefinition for the
+%   study programme. [TV]}
 % \changes{v1.0.0}{2021/04/23}{^^A
 %   The style files for the Faculty of Law at the Masaryk University
 %   in Brno no longer redefine the \cs{thesis@blocks@cover@header}
@@ -53,6 +55,8 @@
 %   layout as per the faculty requirements. Department name and
 %   field are in the upper part of the titlePage. [TV]}
 %    \begin{macrocode}
+\thesis@blocks@titlePage@programme@false
+
 \thesis@xpatch{\thesis@blocks@titlePage}
 {{\sf\thesis@titlePage@large\thesis@@{advisorTitle}: \thesis@advisor}%
    \par\vspace{0.75cm}%
@@ -74,14 +78,14 @@
 
 \thesis@xpatch{\thesis@blocks@titlePage}
 {{\sf\thesis@titlePage@large\thesis@@upper{facultyName}}%
- \par\vspace{1.75cm}%
+ \par\vfill
 }
 {{\sf\thesis@titlePage@large\thesis@@upper{facultyName}}%
  \par\vspace{0.75cm}%
  {\sf\thesis@titlePage@large\thesis@field}%
  \par\vspace{0.25cm}%
  {\sf\thesis@titlePage@large\thesis@department@name}
- \par\vspace{1.75cm}%
+ \par\vspace{4cm}%
 }
 %    \end{macrocode}
 % \begin{macro}{\thesis@blocks@frontMatter}

--- a/style/mu/med.dtx
+++ b/style/mu/med.dtx
@@ -109,7 +109,11 @@
 %   The style files of the Faculty of Medicine at the Masary University
 %   in Brno no longer redefine the \cs{thesis@blocks@cover} macro.
 %   [TV]}
+% \changes{v1.0.0}{2021/05/06}{Added conditional redefinition for the
+%   study field. [TV]}
 %    \begin{macrocode}
+\thesis@blocks@titlePage@field@false
+
 \thesis@xpatch{\thesis@blocks@titlePage}
 {{\sf\thesis@titlePage@large\thesis@@{advisorTitle}: \thesis@advisor}%
    \par\vspace{0.75cm}%
@@ -131,14 +135,14 @@
 
 \thesis@xpatch{\thesis@blocks@titlePage}
 {{\sf\thesis@titlePage@large\thesis@@upper{facultyName}}%
- \par\vspace{1.75cm}%
+ \par\vfill
 }
 {{\sf\thesis@titlePage@large\thesis@@upper{facultyName}}%
  \par\vspace{0.75cm}%
  {\sf\thesis@titlePage@large\thesis@programme}%
  \par\vspace{0.25cm}%
  {\sf\thesis@titlePage@large\thesis@department@name}
- \par\vspace{1.75cm}%
+ \par\vspace{4cm}%
 }
 %    \end{macrocode}
 % \begin{macro}{\thesis@blocks@frontMatter}

--- a/style/mu/sci.dtx
+++ b/style/mu/sci.dtx
@@ -40,6 +40,9 @@
 %   \texttt{abstractonsinglepage} option in
 %   \texttt{style/mu/fithesis-sci.sty}. The patch was submitted by
 %   Juraj Pálenik. [VN]}
+% \changes{v1.0.0}{2021/05/06}{Added redefinition of the conditionals
+%   to exclude the study programme and the study field from the title
+%   page. [TV]}
 % \changes{v1.0.0}{2021/03/12}{^^A
 %   The style file of the Faculty of Science at the Masaryk
 %   University in Brno, Czech Republic no longer defines the
@@ -67,6 +70,9 @@
 % Enable the inclusion of the scanned assignment inside the digital
 % version of the document.
 % \begin{macrocode}
+\thesis@blocks@titlePage@field@false
+\thesis@blocks@titlePage@programme@false
+
 \thesis@blocks@assignment@hideIfDigital@false
 %    \end{macrocode}
 % \begin{macro}{\thesis@blocks@frontMatter}


### PR DESCRIPTION
Some of the faculties only want to have programme or the field on their title page, and some don't want either. 