### PR TITLE
Move title pages into the front matter

### DIFF
--- a/style/mu/econ.dtx
+++ b/style/mu/econ.dtx
@@ -274,8 +274,8 @@
 \def\thesis@blocks@preamble{%
   \thesis@blocks@coverMatter
     \thesis@blocks@cover
-    \thesis@blocks@titlePage
   \thesis@blocks@frontMatter
+    \thesis@blocks@titlePage
     \thesis@blocks@seal
     \thesis@blocks@bibEntry
     \thesis@blocks@abstract

--- a/style/mu/fi.dtx
+++ b/style/mu/fi.dtx
@@ -114,8 +114,8 @@
 \def\thesis@blocks@preamble{%
   \thesis@blocks@coverMatter
     \thesis@blocks@cover
-    \thesis@blocks@titlePage
   \thesis@blocks@frontMatter
+    \thesis@blocks@titlePage
     \thesis@blocks@seal
     \ifx\thesis@type\thesis@proposal
       \thesis@blocks@toc

--- a/style/mu/fsps.dtx
+++ b/style/mu/fsps.dtx
@@ -152,8 +152,8 @@
 \def\thesis@blocks@preamble{%
   \thesis@blocks@coverMatter
     \thesis@blocks@cover
-    \thesis@blocks@titlePage
   \thesis@blocks@frontMatter
+    \thesis@blocks@titlePage
     \thesis@blocks@seal
     \thesis@blocks@bibEntry
     \thesis@blocks@abstract

--- a/style/mu/fss.dtx
+++ b/style/mu/fss.dtx
@@ -67,8 +67,8 @@
 \def\thesis@blocks@preamble{%
   \thesis@blocks@coverMatter
     \thesis@blocks@cover
-    \thesis@blocks@titlePage
   \thesis@blocks@frontMatter
+    \thesis@blocks@titlePage
     \thesis@blocks@seal
     \thesis@blocks@bibEntry
     \thesis@blocks@abstract

--- a/style/mu/law.dtx
+++ b/style/mu/law.dtx
@@ -132,8 +132,8 @@
 \def\thesis@blocks@preamble{%
   \thesis@blocks@coverMatter
     \thesis@blocks@cover
-    \thesis@blocks@titlePage
   \thesis@blocks@frontMatter
+    \thesis@blocks@titlePage
     \thesis@blocks@seal
     \thesis@blocks@declaration
     \thesis@blocks@clear

--- a/style/mu/med.dtx
+++ b/style/mu/med.dtx
@@ -197,8 +197,8 @@
 \def\thesis@blocks@preamble{%
   \thesis@blocks@coverMatter
     \thesis@blocks@cover
-    \thesis@blocks@titlePage
   \thesis@blocks@frontMatter
+    \thesis@blocks@titlePage
     \thesis@blocks@seal
     \thesis@blocks@declaration
     \thesis@blocks@clear

--- a/style/mu/ped.dtx
+++ b/style/mu/ped.dtx
@@ -65,8 +65,8 @@
 \def\thesis@blocks@preamble{%
   \thesis@blocks@coverMatter
     \thesis@blocks@cover
-    \thesis@blocks@titlePage
   \thesis@blocks@frontMatter
+    \thesis@blocks@titlePage
     \thesis@blocks@seal
     \thesis@blocks@bibEntry
     \thesis@blocks@abstract

--- a/style/mu/pharm.dtx
+++ b/style/mu/pharm.dtx
@@ -85,8 +85,8 @@
 \def\thesis@blocks@preamble{%
   \thesis@blocks@coverMatter
     \thesis@blocks@cover
-    \thesis@blocks@titlePage
   \thesis@blocks@frontMatter
+    \thesis@blocks@titlePage
     \thesis@blocks@seal
     \thesis@blocks@bibEntry
     \thesis@blocks@abstract

--- a/style/mu/phil.dtx
+++ b/style/mu/phil.dtx
@@ -87,8 +87,8 @@
 \def\thesis@blocks@preamble{%
   \thesis@blocks@coverMatter
     \thesis@blocks@cover
-    \thesis@blocks@titlePage
   \thesis@blocks@frontMatter
+    \thesis@blocks@titlePage
     \thesis@blocks@seal
 %    \end{macrocode}
 % In KISK theses, the bibliographical entry, the abstract, and the

--- a/style/mu/sci.dtx
+++ b/style/mu/sci.dtx
@@ -113,8 +113,8 @@
 \def\thesis@blocks@preamble{
   \thesis@blocks@coverMatter
     \thesis@blocks@cover
-    \thesis@blocks@titlePage
   \thesis@blocks@frontMatter
+    \thesis@blocks@titlePage
     \thesis@blocks@seal
     \ifx\thesis@type\thesis@proposal
       \thesis@blocks@toc


### PR DESCRIPTION
This pull request moves `\thesis@blocks@titlePage` from `\thesis@blocks@coverMatter` to `\thesis@blocks@frontMatter`. For ECON and MED, this fixes an alignment issue, since the cover matter uses a different page geometry from the front and main matters (closes #42).

**Please note** that both `\thesis@blocks@frontMatter` and `\thesis@blocks@mainMatter` reset page numbering. This makes `\thesis@blocks@titlePage` the first numbered page of the thesis (page number i). Compliance with the page numbering requirements of the individual faculties should be checked before merge!