### PR TITLE
Fix leading and the definition&documentation of \thesis@xpatch

### DIFF
--- a/fithesis.dtx
+++ b/fithesis.dtx
@@ -1832,7 +1832,7 @@
   }}
 %    \end{macrocode}
 % \begin{macro}{\thesis@patch}
-% The |\thesis@patch|\oarg{versions}\oarg{patch} macro expands
+% The |\thesis@patch|\marg{versions}\marg{patch} macro expands
 % \textit{patch}, if |\thesis@version|\texttt{\discretionary{@}^^A
 % {@}{@}}|number| (defined at the top of the file
 % \texttt{fithesis4.cls}) matches any of the comma-delimited
@@ -1857,13 +1857,14 @@
 %    \end{macrocode}
 % \end{macro}
 % \begin{macro}{\thesis@xpatch}
-% The |\thesis@xpatch| macro is used to to replace code in a searched
-% macro by the replacement code via \textit{xpatchcmd} If the 
-% \textit{xpatchcmd} fails, a class error is written to the output.
+% The |\thesis@xpatch|\marg{command}\marg{search}\marg{replace} macro
+% is used to to replace \textit{search} with \textit{replace} in the definition
+% of \textit{command}. If the replacement fails, a class error is written to
+% the output.
 %    \begin{macrocode}
 \long\def\thesis@xpatch#1#2#3{%
-    \xpatchcmd{#1}{#2}{#3}{}%
-      {\ClassError{fithesis4}{The command #1 does not contain searched text}}}
+  \xpatchcmd{#1}{#2}{#3}{}%
+    {\ClassError{fithesis4}{The command \string#1 does not contain the searched text}{}}}
 %    \end{macrocode}
 % \end{macro}
 % \iffalse

--- a/fithesis.dtx
+++ b/fithesis.dtx
@@ -462,6 +462,7 @@
 %   \item\textsf{inputenc} -- Used to enable the input UTF-8
 %     encoding. This package does not get loaded under
 %     the \Hologo{XeTeX} and \Hologo{LuaTeX} engines.
+%   \changes{v1.0.0}{2021/04/30}{Added \cs{thesis@xpatch} command. [TV]}
 %   \item\textsf{xpatch} -- Used to redefine parts of code
 %     in macros without redefining the whole macro.
 % \end{itemize}
@@ -1857,6 +1858,7 @@
 %    \end{macrocode}
 % \end{macro}
 % \begin{macro}{\thesis@xpatch}
+% \changes{v1.0.0}{2021/04/30}{Added \cs{thesis@xpatch} command. [TV]}
 % The |\thesis@xpatch|\marg{command}\marg{search}\marg{replace} macro
 % is used to to replace \textit{search} with \textit{replace} in the definition
 % of \textit{command}. If the replacement fails, a class error is written to

--- a/fithesis.dtx
+++ b/fithesis.dtx
@@ -1866,7 +1866,8 @@
 %    \begin{macrocode}
 \long\def\thesis@xpatch#1#2#3{%
   \xpatchcmd{#1}{#2}{#3}{}%
-    {\ClassError{fithesis4}{The command \string#1 does not contain the searched text}{}}}
+    {\ClassError{fithesis4}{%
+       Command \string#1 does not contain the searched text}{}}}
 %    \end{macrocode}
 % \end{macro}
 % \iffalse

--- a/style/mu/base.dtx
+++ b/style/mu/base.dtx
@@ -773,11 +773,11 @@
         \par\vspace{0.75cm}%
         {\sf\thesis@titlePage@large\thesis@@upper{facultyName}}%
         \par\vfill
-	{\bf\thesis@titlePage@Huge\thesis@TeXtitle}%
-	\par\vspace{1.5cm}
+        {\bf\thesis@titlePage@Huge\thesis@TeXtitle}%
+        \par\vspace{1.5cm}
         {\sf\thesis@titlePage@Large\thesis@@{typeName}}%
-	\par\vspace{1.5cm}
-	{\sf\thesis@titlePage@LARGE\thesis@upper{author}}%
+        \par\vspace{1.5cm}
+        {\sf\thesis@titlePage@LARGE\thesis@upper{author}}%
         \par\vfill
         \sf\thesis@titlePage@large\thesis@place, \thesis@@{semester}%
       \end{center}%
@@ -883,11 +883,11 @@
         {\sf\thesis@titlePage@large\thesis@department@name}
       \fi
       \ifthesis@blocks@titlePage@programme@
-	\par\vspace{0.25cm}%
+        \par\vspace{0.25cm}%
         {\sf\thesis@titlePage@large\thesis@@{bib@programme}: \thesis@programme}\par
       \fi
       \ifthesis@blocks@titlePage@field@
-	\par\vspace{0.25cm}%
+        \par\vspace{0.25cm}%
         {\sf\thesis@titlePage@large\thesis@@{fieldTitle}: \thesis@field@name}%
       \fi
       \par\vfill
@@ -1185,14 +1185,14 @@
     \bf\thesis@@{bib@keywords}:}}
   \let\@skip\relax\newlength{\@skip}\setlength{\@skip}{16pt}
   \let\@left\relax\newlength{\@left}\pgfmathsetlength{\@left}{%
-	  max(\@A,\@B,\@C,\@D,\@E,\@F,\@G,\@H)}
+    max(\@A,\@B,\@C,\@D,\@E,\@F,\@G,\@H)}
   \let\@right\relax\newlength{\@right}\setlength{\@right}{%
     \textwidth-\@left-\@skip}
   % Typeset the table
   \noindent\begin{thesis@newtable@old}%
     {@{}p{\@left}@{\hskip\@skip}p{\@right}@{}}
     \textbf{\thesis@@{bib@author}%
-	  \ifthesis@english\else\ifthesis@woman ka\fi\fi:} &
+    \ifthesis@english\else\ifthesis@woman ka\fi\fi:} &
       \noindent\parbox[t]{\@right}{
         \thesis@author\\
         \thesis@@{facultyName} \\
@@ -1238,7 +1238,7 @@
     \bf\thesis@english@bib@keywords:}}
   \let\@skip\relax\newlength{\@skip}\setlength{\@skip}{16pt}
   \let\@left\relax\newlength{\@left}\pgfmathsetlength{\@left}{%
-	  max(\@A,\@B,\@C,\@D,\@E,\@F,\@G,\@H)}
+    max(\@A,\@B,\@C,\@D,\@E,\@F,\@G,\@H)}
   \let\@right\relax\newlength{\@right}\setlength{\@right}{%
     \textwidth-\@left-\@skip}
   % Typeset the table

--- a/style/mu/base.dtx
+++ b/style/mu/base.dtx
@@ -884,7 +884,7 @@
       \fi
       \ifthesis@blocks@titlePage@programme@
         \vspace{0.25cm}%
-        {\sf\thesis@titlePage@large\thesis@@{bib@programme}: \thesis@programme\par}
+        {\sf\thesis@titlePage@large\thesis@@{bib@programme}: \thesis@programme\par}%
       \fi
       \ifthesis@blocks@titlePage@field@
         \vspace{0.25cm}%

--- a/style/mu/base.dtx
+++ b/style/mu/base.dtx
@@ -769,17 +769,17 @@
       \colorlet{thesis@color@secondary}{black}%
       \thispagestyle{empty}%
       \begin{center}%
-        \thesis@blocks@universityLogo@monochrome
-        \par\vspace{0.75cm}%
-        {\sf\thesis@titlePage@large\thesis@@upper{facultyName}}%
-        \par\vfill
-        {\bf\thesis@titlePage@Huge\thesis@TeXtitle}%
-        \par\vspace{1.5cm}
-        {\sf\thesis@titlePage@Large\thesis@@{typeName}}%
-        \par\vspace{1.5cm}
-        {\sf\thesis@titlePage@LARGE\thesis@upper{author}}%
-        \par\vfill
-        \sf\thesis@titlePage@large\thesis@place, \thesis@@{semester}%
+        \thesis@blocks@universityLogo@monochrome\par
+        \vspace{0.75cm}%
+        {\sf\thesis@titlePage@large\thesis@@upper{facultyName}\par}%
+        \vfill
+        {\bf\thesis@titlePage@Huge\thesis@TeXtitle\par}%
+        \vspace{1.5cm}%
+        {\sf\thesis@titlePage@Large\thesis@@{typeName}\par}%
+        \vspace{1.5cm}%
+        {\sf\thesis@titlePage@LARGE\thesis@upper{author}\par}%
+        \vfill
+        {\sf\thesis@titlePage@large\thesis@place, \thesis@@{semester}\par}%
       \end{center}%
     \end{alwayssingle}%
   \fi}
@@ -869,28 +869,28 @@
     \begin{center}%
       \thesis@blocks@universityLogo@color
       \par\vspace{0.75cm}%
-      {\sf\thesis@titlePage@large\thesis@@upper{facultyName}}%
-      \par\vfill
-      {\bf\thesis@titlePage@Huge\thesis@TeXtitle}%
-      \par\vspace{1.5cm}%
-      {\sf\thesis@titlePage@Large\thesis@@{typeName}}
-      \par\vspace{1.5cm}
-      {\sf\thesis@titlePage@LARGE\thesis@upper{author}}%
-      \par\vfill
-      {\sf\thesis@titlePage@large\thesis@@{advisorTitle}: \thesis@advisor}%
-      \par\vspace{0.75cm}%
+      {\sf\thesis@titlePage@large\thesis@@upper{facultyName}\par}%
+      \vfill
+      {\bf\thesis@titlePage@Huge\thesis@TeXtitle\par}%
+      \vspace{1.5cm}%
+      {\sf\thesis@titlePage@Large\thesis@@{typeName}\par}%
+      \vspace{1.5cm}%
+      {\sf\thesis@titlePage@LARGE\thesis@upper{author}\par}%
+      \vfill
+      {\sf\thesis@titlePage@large\thesis@@{advisorTitle}: \thesis@advisor\par}%
+      \vspace{0.75cm}%
       \ifthesis@blocks@titlePage@department@
-        {\sf\thesis@titlePage@large\thesis@department@name}
+        {\sf\thesis@titlePage@large\thesis@department@name\par}%
       \fi
       \ifthesis@blocks@titlePage@programme@
-        \par\vspace{0.25cm}%
-        {\sf\thesis@titlePage@large\thesis@@{bib@programme}: \thesis@programme}\par
+        \vspace{0.25cm}%
+        {\sf\thesis@titlePage@large\thesis@@{bib@programme}: \thesis@programme\par}
       \fi
       \ifthesis@blocks@titlePage@field@
-        \par\vspace{0.25cm}%
-        {\sf\thesis@titlePage@large\thesis@@{fieldTitle}: \thesis@field@name}%
+        \vspace{0.25cm}%
+        {\sf\thesis@titlePage@large\thesis@@{fieldTitle}: \thesis@field@name\par}%
       \fi
-      \par\vfill
+      \vfill
       {\sf\thesis@titlePage@large\thesis@place, \thesis@@{semester}%
 %    \end{macrocode}
 % If this is a rigorous thesis or a PhD thesis proposal, create
@@ -906,7 +906,7 @@
           \thesis@blocks@advisorSignature
         \else\ifx\thesis@type\thesis@proposal
           \thesis@blocks@advisorSignature
-        \fi\fi}%
+        \fi\fi\par}%
     \end{center}%
   \end{alwayssingle}}
 %    \end{macrocode}

--- a/style/mu/econ.dtx
+++ b/style/mu/econ.dtx
@@ -86,24 +86,23 @@
 % macro does not include the title of the thesis, and typesets the
 % name of the author at the bottom of the page.
 %    \begin{macrocode}
-\def\thesis@blocks@cover{%
-  \ifthesis@cover@
-    \thesis@blocks@clear
-    \begin{alwayssingle}
-      \colorlet{thesis@color@secondary}{black}%
-      \thispagestyle{empty}
-      \begin{center}
-        \thesis@blocks@universityLogo@monochrome\par
-        \vspace{0.75cm}%
-        {\sf\thesis@titlePage@large\thesis@@upper{facultyName}\par}%
-        \vfill
-        {\bf\thesis@titlePage@Huge\thesis@@{typeName}\par}%
-        \vfill
-        {\sf\thesis@titlePage@large\thesis@place
-         \ \sf\thesis@year\hfill\thesis@author\par}
-      \end{center}
-    \end{alwayssingle}
-  \fi}
+\thesis@xpatch{\thesis@blocks@cover}
+{%
+  \vfill
+  {\bf\thesis@titlePage@Huge\thesis@TeXtitle\par}%
+  \vspace{1.5cm}%
+  {\sf\thesis@titlePage@Large\thesis@@{typeName}\par}%
+  \vspace{1.5cm}%
+  {\sf\thesis@titlePage@LARGE\thesis@upper{author}\par}%
+  \vfill
+  {\sf\thesis@titlePage@large\thesis@place, \thesis@@{semester}\par}%
+}{%
+  \vfill
+  {\bf\thesis@titlePage@Huge\thesis@@{typeName}\par}%
+  \vfill
+  {\sf\thesis@titlePage@large\thesis@place
+   \ \sf\thesis@year\hfill\thesis@author\par}%
+}
 %    \end{macrocode}
 % \end{macro}
 % \begin{macro}{\thesis@blocks@frontMatter}

--- a/style/mu/econ.dtx
+++ b/style/mu/econ.dtx
@@ -86,8 +86,7 @@
 % macro does not include the title of the thesis, and typesets the
 % name of the author at the bottom of the page.
 %    \begin{macrocode}
-\thesis@xpatch{\thesis@blocks@cover}
-{%
+\thesis@xpatch\thesis@blocks@cover{%
   \vfill
   {\bf\thesis@titlePage@Huge\thesis@TeXtitle\par}%
   \vspace{1.5cm}%

--- a/style/mu/econ.dtx
+++ b/style/mu/econ.dtx
@@ -94,13 +94,13 @@
       \thispagestyle{empty}
       \begin{center}
         \thesis@blocks@universityLogo@monochrome
-	\par\vspace{0.75cm}%
-	{\sf\thesis@titlePage@large\thesis@@upper{facultyName}}%
-	\par\vfill
-	{\bf\thesis@titlePage@Huge\thesis@@{typeName}}%
-	\vfill
-	{\sf\thesis@titlePage@large\thesis@place
-	 \ \sf\thesis@year\hfill\thesis@author}
+        \par\vspace{0.75cm}%
+        {\sf\thesis@titlePage@large\thesis@@upper{facultyName}}%
+        \par\vfill
+        {\bf\thesis@titlePage@Huge\thesis@@{typeName}}%
+        \vfill
+        {\sf\thesis@titlePage@large\thesis@place
+         \ \sf\thesis@year\hfill\thesis@author}
       \end{center}
     \end{alwayssingle}
   \fi}

--- a/style/mu/econ.dtx
+++ b/style/mu/econ.dtx
@@ -93,14 +93,14 @@
       \colorlet{thesis@color@secondary}{black}%
       \thispagestyle{empty}
       \begin{center}
-        \thesis@blocks@universityLogo@monochrome
-        \par\vspace{0.75cm}%
-        {\sf\thesis@titlePage@large\thesis@@upper{facultyName}}%
-        \par\vfill
-        {\bf\thesis@titlePage@Huge\thesis@@{typeName}}%
+        \thesis@blocks@universityLogo@monochrome\par
+        \vspace{0.75cm}%
+        {\sf\thesis@titlePage@large\thesis@@upper{facultyName}\par}%
+        \vfill
+        {\bf\thesis@titlePage@Huge\thesis@@{typeName}\par}%
         \vfill
         {\sf\thesis@titlePage@large\thesis@place
-         \ \sf\thesis@year\hfill\thesis@author}
+         \ \sf\thesis@year\hfill\thesis@author\par}
       \end{center}
     \end{alwayssingle}
   \fi}

--- a/style/mu/fi.dtx
+++ b/style/mu/fi.dtx
@@ -45,14 +45,14 @@
 % \changes{v1.0.0}{2021/05/06}{Added redefinition of the cover to include
 %   the faculty seal. [TV]}
 %    \begin{macrocode}
-\thesis@xpatch{\thesis@blocks@cover}
-{\vfill
- {\bf\thesis@titlePage@Huge\thesis@TeXtitle\par}%
-}
-{\vspace{2cm}%
- \thesis@blocks@facultyLogo@monochrome\par
- \vspace{2cm}%
- {\bf\thesis@titlePage@Huge\thesis@TeXtitle\par}%
+\thesis@xpatch\thesis@blocks@cover{%
+  \vfill
+  {\bf\thesis@titlePage@Huge\thesis@TeXtitle\par}%
+}{%
+  \vspace{2cm}%
+  \thesis@blocks@facultyLogo@monochrome\par
+  \vspace{2cm}%
+  {\bf\thesis@titlePage@Huge\thesis@TeXtitle\par}%
 }
 %    \end{macrocode}
 % \changes{v1.0.0}{2021/02/26}{^^A

--- a/style/mu/fi.dtx
+++ b/style/mu/fi.dtx
@@ -46,13 +46,13 @@
 %   the faculty seal. [TV]}
 %    \begin{macrocode}
 \thesis@xpatch{\thesis@blocks@cover}
-{\par\vfill
- {\bf\thesis@titlePage@Huge\thesis@TeXtitle}%
+{\vfill
+ {\bf\thesis@titlePage@Huge\thesis@TeXtitle\par}%
 }
-{\par\vspace{2cm}
- \thesis@blocks@facultyLogo@monochrome
- \par\vspace{2cm}
- {\bf\thesis@titlePage@Huge\thesis@TeXtitle}%
+{\vspace{2cm}%
+ \thesis@blocks@facultyLogo@monochrome\par
+ \vspace{2cm}%
+ {\bf\thesis@titlePage@Huge\thesis@TeXtitle\par}%
 }
 %    \end{macrocode}
 % \changes{v1.0.0}{2021/02/26}{^^A

--- a/style/mu/law.dtx
+++ b/style/mu/law.dtx
@@ -58,34 +58,34 @@
 \thesis@blocks@titlePage@programme@false
 
 \thesis@xpatch{\thesis@blocks@titlePage}
-{{\sf\thesis@titlePage@large\thesis@@{advisorTitle}: \thesis@advisor}%
-   \par\vspace{0.75cm}%
+{{\sf\thesis@titlePage@large\thesis@@{advisorTitle}: \thesis@advisor\par}%
+   \vspace{0.75cm}%
    \ifthesis@blocks@titlePage@department@
-     {\sf\thesis@titlePage@large\thesis@department@name}
+     {\sf\thesis@titlePage@large\thesis@department@name\par}%
    \fi
    \ifthesis@blocks@titlePage@programme@
-     \par\vspace{0.25cm}%
+     \vspace{0.25cm}%
      {\sf\thesis@titlePage@large\thesis@@{bib@programme}: 
-      \thesis@programme}\par
+      \thesis@programme\par}%
    \fi
    \ifthesis@blocks@titlePage@field@
-     \par\vspace{0.25cm}%
+     \vspace{0.25cm}%
      {\sf\thesis@titlePage@large\thesis@@{fieldTitle}: 
-      \thesis@field@name}%
+      \thesis@field@name\par}%
    \fi
-   \par\vfill
+   \vfill
 }{}
 
 \thesis@xpatch{\thesis@blocks@titlePage}
-{{\sf\thesis@titlePage@large\thesis@@upper{facultyName}}%
- \par\vfill
+{{\sf\thesis@titlePage@large\thesis@@upper{facultyName}\par}%
+ \vfill
 }
-{{\sf\thesis@titlePage@large\thesis@@upper{facultyName}}%
- \par\vspace{0.75cm}%
- {\sf\thesis@titlePage@large\thesis@field}%
- \par\vspace{0.25cm}%
- {\sf\thesis@titlePage@large\thesis@department@name}
- \par\vspace{4cm}%
+{{\sf\thesis@titlePage@large\thesis@@upper{facultyName}\par}%
+ \vspace{0.75cm}%
+ {\sf\thesis@titlePage@large\thesis@field\par}%
+ \vspace{0.25cm}%
+ {\sf\thesis@titlePage@large\thesis@department@name\par}
+ \vspace{4cm}%
 }
 %    \end{macrocode}
 % \begin{macro}{\thesis@blocks@frontMatter}

--- a/style/mu/law.dtx
+++ b/style/mu/law.dtx
@@ -57,8 +57,8 @@
 %    \begin{macrocode}
 \thesis@blocks@titlePage@programme@false
 
-\thesis@xpatch{\thesis@blocks@titlePage}
-{{\sf\thesis@titlePage@large\thesis@@{advisorTitle}: \thesis@advisor\par}%
+\thesis@xpatch\thesis@blocks@titlePage{%
+  {\sf\thesis@titlePage@large\thesis@@{advisorTitle}: \thesis@advisor\par}%
    \vspace{0.75cm}%
    \ifthesis@blocks@titlePage@department@
      {\sf\thesis@titlePage@large\thesis@department@name\par}%
@@ -76,16 +76,16 @@
    \vfill
 }{}
 
-\thesis@xpatch{\thesis@blocks@titlePage}
-{{\sf\thesis@titlePage@large\thesis@@upper{facultyName}\par}%
- \vfill
-}
-{{\sf\thesis@titlePage@large\thesis@@upper{facultyName}\par}%
- \vspace{0.75cm}%
- {\sf\thesis@titlePage@large\thesis@field\par}%
- \vspace{0.25cm}%
- {\sf\thesis@titlePage@large\thesis@department@name\par}
- \vspace{4cm}%
+\thesis@xpatch\thesis@blocks@titlePage{%
+  {\sf\thesis@titlePage@large\thesis@@upper{facultyName}\par}%
+  \vfill
+}{%
+  {\sf\thesis@titlePage@large\thesis@@upper{facultyName}\par}%
+  \vspace{0.75cm}%
+  {\sf\thesis@titlePage@large\thesis@field\par}%
+  \vspace{0.25cm}%
+  {\sf\thesis@titlePage@large\thesis@department@name\par}%
+  \vspace{4cm}%
 }
 %    \end{macrocode}
 % \begin{macro}{\thesis@blocks@frontMatter}

--- a/style/mu/law.dtx
+++ b/style/mu/law.dtx
@@ -66,12 +66,12 @@
    \ifthesis@blocks@titlePage@programme@
      \par\vspace{0.25cm}%
      {\sf\thesis@titlePage@large\thesis@@{bib@programme}: 
-	\thesis@programme}\par
+      \thesis@programme}\par
    \fi
    \ifthesis@blocks@titlePage@field@
      \par\vspace{0.25cm}%
      {\sf\thesis@titlePage@large\thesis@@{fieldTitle}: 
-	\thesis@field@name}%
+      \thesis@field@name}%
    \fi
    \par\vfill
 }{}

--- a/style/mu/med.dtx
+++ b/style/mu/med.dtx
@@ -123,12 +123,12 @@
    \ifthesis@blocks@titlePage@programme@
      \par\vspace{0.25cm}%
      {\sf\thesis@titlePage@large\thesis@@{bib@programme}: 
-	\thesis@programme}\par
+      \thesis@programme}\par
    \fi
    \ifthesis@blocks@titlePage@field@
      \par\vspace{0.25cm}%
      {\sf\thesis@titlePage@large\thesis@@{fieldTitle}: 
-	\thesis@field@name}%
+      \thesis@field@name}%
    \fi
    \par\vfill
 }{}

--- a/style/mu/med.dtx
+++ b/style/mu/med.dtx
@@ -114,16 +114,16 @@
 %    \begin{macrocode}
 \thesis@blocks@titlePage@field@false
 
-\thesis@xpatch{\thesis@blocks@titlePage}
-{{\sf\thesis@titlePage@large\thesis@@{advisorTitle}: \thesis@advisor\par}%
+\thesis@xpatch\thesis@blocks@titlePage{%
+  {\sf\thesis@titlePage@large\thesis@@{advisorTitle}: \thesis@advisor\par}%
    \vspace{0.75cm}%
    \ifthesis@blocks@titlePage@department@
      {\sf\thesis@titlePage@large\thesis@department@name\par}%
    \fi
    \ifthesis@blocks@titlePage@programme@
      \vspace{0.25cm}%
-     {\sf\thesis@titlePage@large\thesis@@{bib@programme\par}:
-      \thesis@programme}%
+     {\sf\thesis@titlePage@large\thesis@@{bib@programme}:
+      \thesis@programme\par}%
    \fi
    \ifthesis@blocks@titlePage@field@
      \vspace{0.25cm}%
@@ -133,16 +133,16 @@
    \vfill
 }{}
 
-\thesis@xpatch{\thesis@blocks@titlePage}
-{{\sf\thesis@titlePage@large\thesis@@upper{facultyName}\par}%
- \vfill
-}
-{{\sf\thesis@titlePage@large\thesis@@upper{facultyName}\par}%
- \vspace{0.75cm}%
- {\sf\thesis@titlePage@large\thesis@programme\par}%
- \vspace{0.25cm}%
- {\sf\thesis@titlePage@large\thesis@department@name\par}%
- \vspace{4cm}%
+\thesis@xpatch\thesis@blocks@titlePage{%
+  {\sf\thesis@titlePage@large\thesis@@upper{facultyName}\par}%
+  \vfill
+}{%
+  {\sf\thesis@titlePage@large\thesis@@upper{facultyName}\par}%
+  \vspace{0.75cm}%
+  {\sf\thesis@titlePage@large\thesis@programme\par}%
+  \vspace{0.25cm}%
+  {\sf\thesis@titlePage@large\thesis@department@name\par}%
+  \vspace{4cm}%
 }
 %    \end{macrocode}
 % \begin{macro}{\thesis@blocks@frontMatter}

--- a/style/mu/med.dtx
+++ b/style/mu/med.dtx
@@ -115,34 +115,34 @@
 \thesis@blocks@titlePage@field@false
 
 \thesis@xpatch{\thesis@blocks@titlePage}
-{{\sf\thesis@titlePage@large\thesis@@{advisorTitle}: \thesis@advisor}%
-   \par\vspace{0.75cm}%
+{{\sf\thesis@titlePage@large\thesis@@{advisorTitle}: \thesis@advisor\par}%
+   \vspace{0.75cm}%
    \ifthesis@blocks@titlePage@department@
-     {\sf\thesis@titlePage@large\thesis@department@name}
+     {\sf\thesis@titlePage@large\thesis@department@name\par}%
    \fi
    \ifthesis@blocks@titlePage@programme@
-     \par\vspace{0.25cm}%
-     {\sf\thesis@titlePage@large\thesis@@{bib@programme}: 
-      \thesis@programme}\par
+     \vspace{0.25cm}%
+     {\sf\thesis@titlePage@large\thesis@@{bib@programme\par}:
+      \thesis@programme}%
    \fi
    \ifthesis@blocks@titlePage@field@
-     \par\vspace{0.25cm}%
+     \vspace{0.25cm}%
      {\sf\thesis@titlePage@large\thesis@@{fieldTitle}: 
-      \thesis@field@name}%
+      \thesis@field@name\par}%
    \fi
-   \par\vfill
+   \vfill
 }{}
 
 \thesis@xpatch{\thesis@blocks@titlePage}
-{{\sf\thesis@titlePage@large\thesis@@upper{facultyName}}%
- \par\vfill
+{{\sf\thesis@titlePage@large\thesis@@upper{facultyName}\par}%
+ \vfill
 }
-{{\sf\thesis@titlePage@large\thesis@@upper{facultyName}}%
- \par\vspace{0.75cm}%
- {\sf\thesis@titlePage@large\thesis@programme}%
- \par\vspace{0.25cm}%
- {\sf\thesis@titlePage@large\thesis@department@name}
- \par\vspace{4cm}%
+{{\sf\thesis@titlePage@large\thesis@@upper{facultyName}\par}%
+ \vspace{0.75cm}%
+ {\sf\thesis@titlePage@large\thesis@programme\par}%
+ \vspace{0.25cm}%
+ {\sf\thesis@titlePage@large\thesis@department@name\par}%
+ \vspace{4cm}%
 }
 %    \end{macrocode}
 % \begin{macro}{\thesis@blocks@frontMatter}

--- a/style/mu/sci.dtx
+++ b/style/mu/sci.dtx
@@ -125,7 +125,7 @@
       \thesis@blocks@clear
         \thesis@blocks@abstract
       \thesis@blocks@clearRight
-	\thesis@blocks@abstractEn
+        \thesis@blocks@abstractEn
       \thesis@blocks@assignment
       \thesis@blocks@thanks
       \thesis@blocks@declaration


### PR DESCRIPTION
The title text has insufficient [leading](https://practicaltypography.com/line-spacing.html) as shown in #42 (bottom right). This is caused by the following:

``` tex
{\sf\thesis@titlePage@large\thesis@@upper{facultyName}}\par   % Incorrect, will reset to original font before \par.
{\sf\thesis@titlePage@large\thesis@@upper{facultyName}\par}%  % Correct, will only reset to original font after \par.
```
This pull request exhaustively fixes all instances of this error in all definitions, redefinitions, and xpatches of `\thesis@blocks@titlePage` and `\thesis@blocks@cover`. See below for a before-and-after comparison of the title page of FI:

![Updating_fithesis_UVS](https://user-images.githubusercontent.com/603082/118342263-e62a9d00-b522-11eb-92cf-0d89bac311c1.png)

Additionally, this PR changes the `\thesis@blocks@cover` redefinition for ECON to a `\thesis@xpatch`, so that I get to play with it. 😄